### PR TITLE
ASP: fix comment and add link

### DIFF
--- a/_docs/guides/audio-signal-processing.md
+++ b/_docs/guides/audio-signal-processing.md
@@ -299,7 +299,7 @@ amplitude and frequency values.
                (/ suml 15.0))) ; normalise over all oscs
             ((= chan 1) ; right channel
              (let ((sumr 0.0))
-               (dotimes (i 15 15) ; sum over the first 15 oscs
+               (dotimes (i 15 15) ; sum over the remaining 15 oscs
                  (set! sumr (+ sumr ((aref osc_array i)
                                      (aref amp_array i)
                                      (aref freq_array i)))))
@@ -579,5 +579,5 @@ want to build your *own* instruments
 
 If you're interested in a more in-depth explanation of Extempore's
 instrument infrastructure, then you can <span
-role="doc">go and build your own
-tonewheel organ &lt;making-an-instrument&gt;</span>.
+role="doc">go and [build your own
+tonewheel organ]({{site.baseurl}}{% link _docs/reference/guides/making-an-instrument.md)</span>.


### PR DESCRIPTION
This PR fixes an erroneous comment in the `Audio Signal Processing` guide and adds a proper link at the end to `Making an instrument`.

Something to note that might or might not be of interest is that I was unable to make this guide run as is. This might be due to me installing from source, but `saw_c` was commented out in `libs/core/audio_dsp.xtm` and I also had to redefine `delay_c` (which was defined and the file was loaded?). Not sure whether that is because I’m not on one of the releases.

Cheers