### PR TITLE
Feature/add syntax highlight

### DIFF
--- a/_docs/guides/audio-file-io.md
+++ b/_docs/guides/audio-file-io.md
@@ -9,7 +9,7 @@ files.
 First, load up the required libraries and create an audio file closure with
 `audiofile_c`
 
-~~~~ sourceCode
+~~~~ xtlang
 (sys:load "libs/external/sndfile.xtm")
 
 (bind-func dsp:DSP 1000000000  ;; allocate memory to store the audio file
@@ -49,7 +49,7 @@ the file it wraps to the start, so the file playback will loop on forever.
 To mess with this audio stream, let's add some valve saturation-style distortion
 to both channels:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp:DSP 1000000000
   (let ((audiofile (audiofile_c "/Users/ben/Desktop/xtm-assets/peg.wav" 0 0))
         (saturationl (saturation_c))
@@ -70,7 +70,7 @@ samples into. Looking at the file info which was printed out earlier (in
 particular `samples read: 21202944`), we know that there are `21202944` samples
 in the input file, so that's how big we want our output buffer to be.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp:DSP 1000000000
   (let ((audiofile (audiofile_c "/Users/ben/Desktop/xtm-assets/peg.wav" 0 0))
         (saturationl (saturation_c))
@@ -110,7 +110,7 @@ takes four arguments:
 
 Let's add a function `write_data` to write the audio file:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp:DSP 1000000000
   (let ((audiofile (audiofile_c "/Users/ben/Desktop/xtm-assets/peg.wav" 0 0))
         (saturationl (saturation_c))

--- a/_docs/guides/common-lisp-music.md
+++ b/_docs/guides/common-lisp-music.md
@@ -6,7 +6,7 @@ Here's an example of how to do
 [CLM](https://ccrma.stanford.edu/software/clm/)-style musicmaking in Extempore.
 First, we load in the DSP library:
 
-~~~~ sourceCode
+~~~~ xtlang
 (sys:load "libs/core/audio_dsp.xtm")
 ~~~~
 
@@ -14,7 +14,7 @@ We need a *master* DSP callback. We can call it whatever we like, but by
 convention we call it `dsp`. It's type **must** be
 `[float,float,i64,i64,float*]*`
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp
   (let ((oscil (osc_c 0.0))) ;; instantiates an oscilator with phase 0.0
     (lambda (in:float time:i64 chan:i64 dat:float*)
@@ -27,13 +27,13 @@ We need to tell extempore what we called our DSP callback function using
 `dsp:set!`. We only call `dsp:set!` once per session---from that point until the
 end of the session this function is the audio callback
 
-~~~~ sourceCode
+~~~~ xtlang
 (dsp:set! dsp)
 ~~~~
 
 We can of course recompile `dsp` on-the-fly:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp
   (let ((oscil (osc_c 0.0)))
     (lambda (in:float time:i64 chan:i64 dat:float*)
@@ -45,7 +45,7 @@ We can of course recompile `dsp` on-the-fly:
 Now we have two oscillators, one for the left channel and one for the right. We
 also introduce `DSP`, a type alias for `[float,float,i64,i64,float*]*`
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp:DSP
   (let ((oscil_left (osc_c 0.0))
         (oscil_right (osc_c 0.0)))
@@ -61,7 +61,7 @@ also introduce `DSP`, a type alias for `[float,float,i64,i64,float*]*`
 Equivalently, Extempore's audio DSP library has multi-channel oscillators, so we
 can clean up our code a bit:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp:DSP
   (let ((oscil (osc_mc_c 0.0)))
     (lambda (in time chan dat)
@@ -71,7 +71,7 @@ can clean up our code a bit:
 Let's add a frequency sweep. `SRf` is a global variable which holds the audio
 sample rate (f for `float`)
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp:DSP
   (let ((oscil (osc_mc_c 0.0))
         (duration (* SRf 1.0))      ;; samplerate * 1.0 seconds
@@ -84,7 +84,7 @@ sample rate (f for `float`)
 Now, we can "granulate" the rising oscillator. With the default settings, the
 the granulator will have little effect on the original signal.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp:DSP
   (let ((oscil (osc_mc_c 0.0))
         (duration (* SRf 1.0))      ;; samplerate * 1.0 seconds
@@ -100,12 +100,12 @@ Extempore's granulator is stochastic and supports lo and hi ranges for most
 parameters, making a stochastic choice for each grain in that range. You can get
 determinstic behaviour by making lo and hi the same value.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp:DSP
   (let ((oscil (osc_mc_c 0.0))
         (duration (* SRf 1.0))
         (range (/ 440.0 duration))
-        (grains (granulator_c 2))) 
+        (grains (granulator_c 2)))
     ;; set some initial values
     (grains.iot 500)     ;; inter-offset time (time between grains in samples)
     (grains.dlo 1000.0)  ;; shortest (i.e. low)  duration (in samples)

--- a/_docs/guides/making-an-instrument.md
+++ b/_docs/guides/making-an-instrument.md
@@ -115,7 +115,7 @@ for each drawbar), then that's what we need to generate. There are lots of ways
 to do this, but one nice way is to use oscillator closures created by
 Extempore's `osc_c` function.
 
-~~~~ sourceCode
+~~~~ xtlang
 (sys:load "libs/core/instruments.xtm")
 
 (bind-func organ_drone
@@ -188,7 +188,7 @@ are in the memory pointed to by `tonewheel`), you'd be right. Each closure
 'closes over' a state variable called `phase`, which you can see in the source
 for `osc_c` (which is in `libs/core/audio_dsp.xtm`)
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func osc_c
   (lambda (phase)
     (lambda (amp freq)
@@ -208,7 +208,7 @@ the *two* `lambda` forms: the outer one (with one `phase` argument) defines the
 creates the closure which is returned by `osc_c`. *That's* the closure that gets
 stored in the `tonewheel` array when we perform the loop:
 
-~~~~ sourceCode
+~~~~ xtlang
 (dotimes (i num_drawbars)
           (pset! tonewheel i (osc_c 0.0)))
 ~~~~
@@ -294,7 +294,7 @@ maintaining the state of all the notes being played at any given time.
 So, when we finally define our hammond organ instrument, the definition will
 look like this
 
-~~~~ sourceCode
+~~~~ xtlang
 (make-instrument organ organ)
 ~~~~
 
@@ -318,7 +318,7 @@ Extempore instrument is that the instrument needs to be called in the `dsp`
 callback. If we *only* want our organ in the audio output, then that's as simple
 as
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func dsp:DSP
   (lambda (in time chan dat)
     ;; call the organ instrument closure
@@ -393,7 +393,7 @@ we've been pursuing since the beginning.
 The 'template' for the note kernel and effects kernel is something like this
 (this is just a skeleton---it won't compile)
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func organ_note_c
   (lambda ()
     (lambda (time:i64 chan:i64 freq:float amp:float)
@@ -424,7 +424,7 @@ multi-channel instruments should be obvious---just use a bigger `cond` form!
 To make the `organ_note_c` kernel, we'll fill in the template from the
 `organ_drone` closure we made earlier.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func organ_note_c
   (let ((num_drawbars:i64 9)
         (freq_ratio:SAMPLE* (zalloc num_drawbars))
@@ -494,7 +494,7 @@ approximation of this effect. In particular, our `organ_fx` kernel will use a
 frequencies between the L and R channels) to simulate the sound of a Leslie
 speaker.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func organ_fx 100000
   (let ((flanl (flanger_c 1.0 0.0 0.6 1.0))
         (flanr (flanger_c 1.0 0.0 0.6 1.0))
@@ -526,7 +526,7 @@ Now, let's see if our instrument works! Having compiled both `organ_note_c` and
 `organ_fx`, we're finally ready to use `make-instrument` to make our xtlang
 hammond organ
 
-~~~~ sourceCode
+~~~~ xtlang
 (make-instrument organ organ_note_c organ_fx)
 
 ;; Compiled organ >>> [float,float,i64,i64,float*]*
@@ -540,7 +540,7 @@ hammond organ
 
 and the moment of truth...
 
-~~~~ sourceCode
+~~~~ xtlang
 (play-note (now)   ;; time
            organ   ;; instrument
            60      ;; pitch (midi note number, middle C = 60)

--- a/_docs/guides/note-level-music.md
+++ b/_docs/guides/note-level-music.md
@@ -19,8 +19,8 @@ understand any of that to make music in Extempore.
 This is about the simplest program you can write in Extempore. It loads an
 instrument and plays a single note.
 
-~~~~ sourceCode
-;; load the instruments file 
+~~~~ xtlang
+;; load the instruments file
 (sys:load "libs/core/instruments.xtm")
 
 ;; define a synth using the provided component fmsynth
@@ -51,7 +51,7 @@ We can also create Scheme functions to trigger more complex musical structures.
 Evaluate the following expression to define a function `chord` that, when
 called, will play a chord on the `synth` instrument.
 
-~~~~ sourceCode
+~~~~ xtlang
 (define chord
    (lambda ()
       (play-note (now) synth 60 80 *second*)
@@ -62,7 +62,7 @@ called, will play a chord on the `synth` instrument.
 Once `chord` is defined you can then call it as many times as you like by
 evaluating the following expression:
 
-~~~~ sourceCode
+~~~~ xtlang
 (chord)
 ~~~~
 
@@ -78,7 +78,7 @@ instead of printing it to the log.
 
 Following on from the code we evaluated before to set up the `synth`
 
-~~~~ sourceCode
+~~~~ xtlang
 ; hello world as a list of note pitches
 ; transposed down two octaves (24 semitones)
 (define melody (map (lambda (c)
@@ -156,7 +156,7 @@ Before we do that (if you haven't already), you'll have to set up an instrument
 (in this case the built-in `synth`) and put it somewhere in the `dsp` output
 callback:
 
-~~~~ sourceCode
+~~~~ xtlang
 (sys:load "libs/core/instruments.xtm")
 
 ;; define a synth using the provided component fmsynth
@@ -176,7 +176,7 @@ First, let's implement a simple iterative process. Remember that in MIDI note
 numbers (which `play-note` uses) `60` is middle C, `61` is C\#, `62` is D,
 etc...
 
-~~~~ sourceCode
+~~~~ xtlang
 (dotimes (i 8)
   (play-note (+ (now) (* i 5000)) synth (+ 60 i) 80 4000))
 ~~~~
@@ -187,7 +187,7 @@ play a whole tone scale. Let's use recursion to solve this problem. Ok Scheme
 newbies, time find out about
 [named](http://www.scheme.com/tspl3/control.html#g90) `let`!
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; recursive whole-tone scale
 (let loop ((i 0))
   (play-note (+ (now) (* i 2500)) synth (+ 60 i) 80 4000)
@@ -201,7 +201,7 @@ recursion the better :)
 So, linear sequences don't seem to present a problem. How about a major scale?
 Recursion can handle this for us
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; recursive major scale
 (let loop ((scale '(0 2 4 5 7 9 11 12))
            (time 0))
@@ -213,7 +213,7 @@ Recursion can handle this for us
 We also added a second argument to loop: `time`. Let's use the `time` argument
 to add changing durations to our scale.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; recursive major scale with rhythm
 (let loop ((scale '(0 2 4 5 7 9 11 12))
            (dur '(22050 11025 11025 22050 11025 11025 44100 44100))
@@ -227,7 +227,7 @@ Now that we have pitches and rhythms mastered how do we go about playing a
 chord? The new `time` argument from the previous examples should give you a
 pretty good clue---we just ditch the `time` argument!
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; recursive chord
 (let loop ((chord '(0 4 7)))
   (play-note (now) synth (+ 60 (car chord)) 80 44100)
@@ -244,7 +244,7 @@ pretty good clue---we just ditch the `time` argument!
 C Major---nice! We seem to be using lists a lot, so you're probably just dying
 to use `map`, so here goes.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; map calls lambda for each argument of list
 (map (lambda (p)
        (play-note (now) synth p 80 44100))
@@ -256,7 +256,7 @@ always use `map`? There are a couple of reasons why sometimes it's better not to
 use `map` but we'll come to those soon enough. For the moment let's look at how
 we can use `map` to play a broken chord.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; map broken chord
 (map (lambda (p d)
        (play-note (+ (now) d) synth p 80 (- 88200 d)))
@@ -271,7 +271,7 @@ instead designed specifically to trigger side effects (i.e. playing notes in
 this instance). So if you don't need to return a list, use `for-each` instead of
 `map`.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; for-each broken chord with volumes
 (for-each (lambda (p d v)
             (play-note (+ (now) d) synth p v (- 88200 d)))
@@ -292,7 +292,7 @@ various ways to play a sequence of notes, and we're now going to expand on that
 theme. Let's define a function that uses `callback` to temporally recurse
 through a list of pitch values.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; plays a sequence of pitches
 (define play-seq
   (lambda (time plst)
@@ -307,7 +307,7 @@ This should look very similar to the example in the previous section, but there
 are some subtle differences. To demonstrate, let's change `play-seq` so that it
 keeps playing the sequence indefinitely.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; loop over a sequence of pitches indefinitely
 (define play-seq
   (lambda (time plst)
@@ -329,7 +329,7 @@ nothing: `(define play-seq (lambda args))`.
 
 Let's extend `play-seq` to include a rhythm list (`rlst`) as well.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; plays a sequence of pitches
 (define play-seq
   (lambda (time plst rlst)
@@ -363,7 +363,7 @@ but what if we would like to change the list programmatically. No problem, just
 use a function instead of a literal list---of course this is now no longer an
 ostinati!
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; plays a random pentatonic sequence of notes
 (define play-seq
   (lambda (time plst rlst)
@@ -385,7 +385,7 @@ on down beats. We can make a small modification to the previous example to
 demonstrate this simple little cheat. Also we'll shorten the durations a little
 (constant legato gets a touch boring).
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; plays a random pentatonic sequence of notes with a metric pulse
 (define play-seq
   (lambda (time plst rlst)
@@ -426,7 +426,7 @@ Now, the observant reader will note that we can use modulo arithmetic to find
 MIDI pitches of octave equivalence by using mod `12`. Try running this example,
 and check the log for the printed results.
 
-~~~~ sourceCode
+~~~~ xtlang
 (dotimes (i 12)
   (println 'modulo (+ i 60) 12 '=> (modulo (+ i 60) 12)))
 ~~~~
@@ -441,7 +441,7 @@ Let's start with something simple. We can define a pitch class set by creating a
 list of pitch classes that belong to the set. We can then test a pitch against
 that set by using `pc:?`
 
-~~~~ sourceCode
+~~~~ xtlang
 (sys:load "libs/core/pc_ivl.xtm")
 
 ;; four examples tested against the pitch class set representation of a C major chord
@@ -454,7 +454,7 @@ that set by using `pc:?`
 We can also choose a random pitch from a pitch class set between a lower and
 upper bound.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; this chooses a C in any octave
 (pc:random 0 127 '(0))
 
@@ -471,7 +471,7 @@ fifth (you can try both) to supply a harmony. What does this have to do with
 pitch classes? Well, you can't just transpose up a fifth by adding 7 to
 everything:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; up 7 semitones or a perfect fifth
 (map (lambda (p)
        (pc:? (+ p 7) '(0 2 4 5 7 9 11)))
@@ -495,7 +495,7 @@ that we do use map here instead of for-each because we *do* want to return a
 list (of boolean values). So the answer is to use `pc:relative`, which will
 choose a pitch value from the pitch class relative to our current pitch.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; this gives us 62
 (pc:relative 60 1 '(0 2 4 5 7 9 11))
 
@@ -512,7 +512,7 @@ choose a pitch value from the pitch class relative to our current pitch.
 One more rule about an organum: we need our melody and harmony to start and
 finish on the same note (C). Here's one way we could go about the task:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; define a melody
 (define melody (make-list-with-proc 24
                                     (lambda (i)
@@ -555,7 +555,7 @@ also use `pc:relative` to implement a random walk melody. The rest of the code
 can stay the same, but remember to reevaluate everything that the change
 effects---in this case everything to do with creating `melody` and `harmony`.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; define a random walk melody seeded with 60
 ;; (we remove this at the end with cdr)
 (define melody
@@ -584,7 +584,7 @@ chord that starts to evolve. If your machine will handle a higher callback rate
 then go for it, we're after a wash of sound here. Try choosing a sound with a
 delay for extra impact.
 
-~~~~ sourceCode
+~~~~ xtlang
 (define crazy-chord
   (lambda (time)
     (play-note time synth (pc:random 24 97 '(0 4 7 10 2 3 5 9 6 11 1)) 80 500)
@@ -598,7 +598,7 @@ Ok, so we've seen how we can use a pitch class to represent a chord.
 returning a 'random' chord based on a pitch class set. Let's take a look at this
 in action:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; C-major and repeat
 (define chords
   (lambda (time)
@@ -625,7 +625,7 @@ I'm getting a little sick of C-major, so let's add chord `IV` (F major) and `V`
 callbacks. Note that `random` can just as easily choose a *list* from a list as
 an *atom* from a list.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; I IV V
 (define chords
   (lambda (time chord)
@@ -683,7 +683,7 @@ Language](http://www.scheme.com/tspl3/objects.html) is a good online resource).
 For this first effort we're going to assume the key of C major and I'm going to
 limit the example to the `I`, `IV` and `V` chords only.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; markov chord progression I IV V
 (define progression
   (lambda (time chord)
@@ -709,7 +709,7 @@ Scheme symbols are lowercase only we use `i` for `I` `v` for `V`, etc. Because
 means `I` and that `vii` means `viio` in the major key. In minor `i` will be
 minor etc... Let's look at an example that implements our entire matrix.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; markov chord progression I ii iii IV V vi vii
 (define progression
   (lambda (time degree)
@@ -735,7 +735,7 @@ changes:
 1.  we'll randomly add mordants
 2.  we'll make I and IV twice the duration of the other chords
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; create our organ instrument (again, analogue
  ;; is defined in libs/core/instruments.xtm
 (make-instrument organ analogue)
@@ -799,7 +799,7 @@ everywhere). Now to do this, we're going to cheat and use `pc:relative` to move
 from our chord tones on *off beats*---Schoenberg would be most displeased! We'll
 also add an even longer duration option for `I` and `IV`.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; Quintet
 (define progression
   (lambda (time degree)
@@ -849,7 +849,7 @@ _docs/guides/sampler.md %}) for details on how to set that up. At the end of
 this page you'll find a list of general MIDI drum numbers which I'll be using in
 this tutorial: `*gm-cowbell*`, etc...
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; assuming you've set up and loaded the drums sampler
 (bind-func dsp:DSP
   (lambda (in time chan dat)
@@ -868,7 +868,7 @@ this tutorial: `*gm-cowbell*`, etc...
 And here's one way that we could go about transforming this into a more abstract
 notion of time.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; beat loop
 (define drum-loop
   (lambda (time dur)
@@ -891,7 +891,7 @@ Let's play back the same example at 120 beats per minute (bpm)---remembering
 that by default the Extempore metronome runs at 60 bpm. We'll also add triplets
 to our quavers and semi-quavers.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; beat loop at 120bpm
 (define drum-loop
   (lambda (time dur)
@@ -906,7 +906,7 @@ to our quavers and semi-quavers.
 Let's try using an oscillator to drift the playback speed back and forth over
 time.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; beat loop with tempo shift
 (define drum-loop
   (lambda (time dur)
@@ -933,7 +933,7 @@ provides a mapping from beats (which are nice to work with) to samples (which
 Extempore needs to work with). This makes more sense as a practical exercise, so
 let me demonstrate.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; create a metronome starting at 120 bpm
 (define *metro* (make-metro 120))
 
@@ -969,7 +969,7 @@ How about those tempo changes? No problem---we just need to use pass another
 message to `*metro*` closure: `set-tempo`, which sets a new tempo in bpm (and
 don't forget to quote the symbol).
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; create a metronome starting at 120 bpm
 (define *metro* (make-metro 120))
 
@@ -991,7 +991,7 @@ argument to the `get-beat` message that asks the metronome to return a beat
 number which is equal to `0` mod `4`. I'm going to play cowbell and triangle
 with a slight `0.25` offset.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; create a metronome starting at 120 bpm
 (define *metro* (make-metro 120))
 
@@ -1042,7 +1042,7 @@ revolving metres. Some examples:
 Let's try using a `make-metre`. We'll only play the first beat of each
 bar.
 
-~~~~ sourceCode
+~~~~ xtlang
 (define *metro* (make-metro 90))
 
 ;; a 2/8 3/8 2/8 cycle
@@ -1062,7 +1062,7 @@ Well, that was easy. Let's complicate things just a little by adding a second
 metre. We'll play the side stick for the first metre and the snare for the
 second metre.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; classic 2 against 3
 (define *metro* (make-metro 180))
 
@@ -1092,7 +1092,7 @@ competing metric structures---both of which will be symmetric `(2/8 3/8 4/8 3/8
 in length we should get some nice phasing effects, *a la* Steve Reich. I'm also
 going to add some hi-hats to give it a constant pulse.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; messiaen drum kit
 (define *metro* (make-metro 140))
 
@@ -1128,7 +1128,7 @@ is fine as long as our time increment has a suitable ratio to both metres.
 Let's keep going with this idea and add some pitched musical content as well,
 using the `synth` and `organ` instruments we were using earlier
 
-~~~~ sourceCode
+~~~~ xtlang
 (sys:load "libs/core/pc_ivl.xtm")
 
 ;; messiaen drum kit

--- a/_docs/guides/sampler.md
+++ b/_docs/guides/sampler.md
@@ -93,7 +93,7 @@ of Extempore's sampler called `drums`. To do this, we use the `make-instrument`
 Scheme macro (once we've loaded it from the `libs/external/instruments_ext.xtm`
 library file).
 
-~~~~ sourceCode
+~~~~ xtlang
 (sys:load "libs/external/instruments_ext.xtm")
 
 ;; define a sampler (called drums) using the default sampler note kernel and effects
@@ -128,7 +128,7 @@ subdirectory called `OH`, which contains the wave files which contain the drum
 sounds. We're going to load (some of) these files into our `drums` sampler one
 at a time using the `set-sampler-index` function.
 
-~~~~ sourceCode
+~~~~ xtlang
 (define drum-path "/Users/ben/Music/sample-libs/drums/salamander/OH/")
 (set-sampler-index drums (string-append drum-path "kick_OH_F_9.wav") *gm-kick* 0 0 0 1)
 (set-sampler-index drums (string-append drum-path "snareStick_OH_F_9.wav") *gm-side-stick* 0 0 0 1)
@@ -169,7 +169,7 @@ could have gone wrong:
 
 Assuming things worked properly, we should be able to play our `drums` sampler.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; evaluate these as you see fit!
 (play-note (now) drums *gm-kick* 80 44100)
 (play-note (now) drums *gm-snare* 80 44100)
@@ -190,7 +190,7 @@ sure you can think of lots of other possibilities—go nuts :)
 
 Ok, drums are loaded, let's add one more sampler---this time a `piano`.
 
-~~~~ sourceCode
+~~~~ xtlang
 (make-instrument piano sampler)
 
 ;; add the piano sampler to the dsp output callback
@@ -212,11 +212,11 @@ wave audio files should be in a `44.1khz16bit` subdirectory. Looking at the
 files in that directory (e.g. with `ls`), we get something like
 
 ~~~~ sourceCode
-A0v1.wav   A5v6.wav   C4v2.wav    D#2v13.wav  F#1v1.wav   F#6v6.wav 
-A0v10.wav  A5v7.wav   C4v3.wav    D#2v14.wav  F#1v10.wav  F#6v7.wav 
-A0v11.wav  A5v8.wav   C4v4.wav    D#2v15.wav  F#1v11.wav  F#6v8.wav 
-A0v12.wav  A5v9.wav   C4v5.wav    D#2v16.wav  F#1v12.wav  F#6v9.wav 
-A0v13.wav  A6v1.wav   C4v6.wav    D#2v2.wav   F#1v13.wav  F#7v1.wav 
+A0v1.wav   A5v6.wav   C4v2.wav    D#2v13.wav  F#1v1.wav   F#6v6.wav
+A0v10.wav  A5v7.wav   C4v3.wav    D#2v14.wav  F#1v10.wav  F#6v7.wav
+A0v11.wav  A5v8.wav   C4v4.wav    D#2v15.wav  F#1v11.wav  F#6v8.wav
+A0v12.wav  A5v9.wav   C4v5.wav    D#2v16.wav  F#1v12.wav  F#6v9.wav
+A0v13.wav  A6v1.wav   C4v6.wav    D#2v2.wav   F#1v13.wav  F#7v1.wav
 A0v14.wav  A6v10.wav  C4v7.wav    D#2v3.wav   F#1v14.wav  F#7v10.wav
 
 ... plus many more files
@@ -281,7 +281,7 @@ file starts playing from the start) and plays for its whole length. Writing a
 Scheme function which can do this parsing isn't too difficult, and would look
 something like this
 
-~~~~ sourceCode
+~~~~ xtlang
 (define parse-salamander-piano
   (lambda (file-list)
     (map (lambda (fname)
@@ -312,7 +312,7 @@ load into bank `0` and forget about it.
 
 And finally, to try it out:
 
-~~~~ sourceCode
+~~~~ xtlang
 (play-note (now) piano (random 40 80) 80 44100)
 ~~~~
 

--- a/_docs/overview/contributing.md
+++ b/_docs/overview/contributing.md
@@ -33,13 +33,17 @@ no pull request is too small to be appreciated :)
 To generate these docs, you'll need a working ruby install & a few packages. The
 best way to get started is to use [bundler](http://bundler.io/), then it's:
 
+~~~~ sourceCode
     bundle install # to get all the packages
     bundle exec jekyll build # to build the docs website
+~~~~
 
 If you want to see your changes locally (which of course you do!) then you can
 run a local 'live' test server with
 
+~~~~ sourceCode
     bundle exec jekyll serve
+~~~~
 
 ### Hosting
 

--- a/_docs/overview/install.md
+++ b/_docs/overview/install.md
@@ -29,7 +29,7 @@ run the examples, etc.
 ## Option 2: build from source {#build-from-source}
 
 The build-from-source workflow will download and build all the dependencies you
-need (including LLVM). 
+need (including LLVM).
 
 If you've got the requirements:
 
@@ -40,11 +40,13 @@ If you've got the requirements:
 
 then here are some one-liner build commands:
 
+~~~~ sourceCode
     # linux/macOS
     git clone https://github.com/digego/extempore && mkdir extempore/cmake-build && cd extempore/cmake-build && cmake .. && make install
 
     # Windows
     git clone https://github.com/digego/extempore && mkdir extempore/cmake-build && cd extempore/cmake-build && cmake -G"Visual Studio 15 2017 Win64" .. && cmake --build . --target ALL_BUILD --config Release
+~~~~
 
 If you have problems, check out the platform-specific build notes below.
 
@@ -60,7 +62,7 @@ Here are a few of the more interesting CMake options:
   will also download and build the extended libraries (e.g. glfw, libsndfile).
   If you want to get those things through another package manager (or not use
   them at all) then set this to `OFF`.
-  
+
 - `EXTERNAL_SHLIBS_AUDIO`/`EXTERNAL_SHLIBS_GRAPHICS` (boolean, default `ON` for
   both) are useful if you want to build the supporting libs for graphics/audio
   but not both (so you should set the one you *don't* want to `OFF`)
@@ -113,7 +115,9 @@ Fedora, Arch, and also inside a docker container.
 There are a few extra dependencies which you may need to get through
 your package manager. For example, on Ubuntu 16.04 I needed:
 
+~~~~ sourceCode
     sudo apt-get install libasound2-dev xorg-dev libglu1-mesa-dev zlib1g-dev
+~~~~
 
 You'll also need to specify an [ALSA](http://www.alsa-project.org/) backend for
 portaudio. To use the asound portaudio backend (the default) you'll need the
@@ -197,8 +201,10 @@ it yourself, then here's how.
 Grab the [3.8.0 source tarball](http://llvm.org/releases/download.html#3.8.0),
 apply the `extempore-llvm-3.8.0.patch` in `extras/`:
 
+~~~~ sourceCode
     cd /path/to/llvm-3.8.0.src
     patch -p0 < /path/to/extempore/extras/extempore-llvm-3.8.0.patch
+~~~~
 
 On **Windows**, the `<` redirection will work with `cmd.exe`, but not
 PowerShell.
@@ -206,8 +212,10 @@ PowerShell.
 Then build LLVM, moving the libraries into `/path/to/extempore/llvm` as part of
 the `install` step:
 
+~~~~ sourceCode
     mkdir cmake-build && cd cmake-build
     cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DCMAKE_INSTALL_PREFIX=c:/path/to/extempore/llvm .. && make && make install
+~~~~
 
 On **Windows**, you'll also need to specify a 64-bit generator e.g. `-G"Visual
 Studio 15 2017 Win64"`
@@ -222,7 +230,9 @@ in there to find `llc`).
 If LLVM complains about not being able to find python, you can specify a path to
 your python executable with the `PYTHON_EXECUTABLE` CMake variable:
 
+~~~~ sourceCode
     cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DCMAKE_INSTALL_PREFIX=c:/path/to/extempore/llvm -DPYTHON_EXECUTABLE=c:/path/to/python .. && make && make install
+~~~~
 
 If you **do** build your own patched version of LLVM for Extempore, then make
 sure you set the `EXT_LLVM_DIR` environment variable to point to that directory

--- a/_docs/overview/philosophy.md
+++ b/_docs/overview/philosophy.md
@@ -25,7 +25,7 @@ languages.
 
 This is all a bit abstract, so let's look at a couple of examples:
 
-~~~~ sourceCode
+~~~~ xtlang
 (define scheme-closure
   (lambda (a b)
     (let ((result (* a b)))
@@ -83,7 +83,7 @@ design a new language which has aspects of both)? By way of explanation, let's
 do a bit of numerical processing. Say we want to calculate the highest common
 factor of two integers `a` and `b` using a brute-force approach:
 
-~~~~ sourceCode
+~~~~ xtlang
 (define hcf-scheme
   (lambda (a b)
     (letrec ((hcf (lambda (i)
@@ -118,7 +118,7 @@ arguments and returns another `i64`. In more complex functions there may be a
 greater need to specify the types of the variables, but often just a few type
 annonations can unambiguously determine everything in scope.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; first, figure out two large numbers with a common factor (133)
 (println (map (lambda (x) (* x 133)) '(125219 123711))) ;; prints (16654127 16453563)
 

--- a/_docs/overview/quickstart.md
+++ b/_docs/overview/quickstart.md
@@ -42,7 +42,7 @@ on how to get started hacking Extempore code in your editor of choice.
 
 Hello, World! is pretty straightforward in Extempore
 
-~~~~ sourceCode
+~~~~ xtlang
 (println "Hello, World!")
 ~~~~
 
@@ -51,7 +51,7 @@ Hello, World! is pretty straightforward in Extempore
 Since Extempore has multimedia programming as a core part of its DNA,
 here's "Hello, Sine!"
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func sine:DSP
   (lambda (in time chan dat)
     (* .1 (cos (* (convert time) .04)))))
@@ -63,11 +63,11 @@ here's "Hello, Sine!"
 If you want to turn it off, just re-define the `dsp` function to return
 "silence":
 
-```
+~~~~ xtlang
 (bind-func sine:DSP
   (lambda (in time chan dat)
     0.0))
-```
+~~~~
 
 In the snipped above we've used `0.0`, but any constant value will work (because
 physics).

--- a/_docs/overview/time.md
+++ b/_docs/overview/time.md
@@ -12,7 +12,7 @@ environment where programs are modified and extended while they are running. As
 a simple example: type the following code into your editor and
 [evaluate]({{site.baseurl}}{% link _docs/overview/using-extempore.md %}) it:
 
-~~~~ sourceCode
+~~~~ xtlang
 (now)
 ~~~~
 
@@ -52,7 +52,7 @@ execution) for execution in the future is *super handy*. As an example, let's
 load up the default synth instrument and play three notes in sequence (an
 arpeggiated triad).
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; load the instruments file
 (sys:load "libs/core/instruments.xtm")
 
@@ -118,7 +118,7 @@ a temporally recursive callback loop is established. Here is an example
 demonstrating a `foo` function that will play a note and then schedule itself to
 be called back in one second (this loop will continue indefinitely).
 
-~~~~ sourceCode
+~~~~ xtlang
 (define foo
   (lambda ()
     (play-note (now) synth 60 80 *second*)
@@ -144,7 +144,7 @@ functionality on the fly (provided that the signature of the method does not
 change, i.e. same arguments and same name). Try evaluating the code below while
 the old version of foo is running.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; re-define foo
 (define foo
   (lambda ()
@@ -157,7 +157,7 @@ One-off anonymous functions can also be scheduled for future evaluation. The
 code example below shows a one off anonymous function scheduled for evaluation
 one minute from `(now)`.
 
-~~~~ sourceCode
+~~~~ xtlang
 (callback (+ (now) *minute*)
           (lambda () (play-note (now) synth 60 80 *second*)))
 ~~~~
@@ -168,7 +168,7 @@ below, the two notes *may* be scheduled to play on the same sample, but then
 again, they may not! `(now)` may have moved forward in time between the two
 calls, even if they were evaluated at the same time.
 
-~~~~ sourceCode
+~~~~ xtlang
 (play-note (now) synth 60 80 *second*)
 (play-note (now) synth 72 80 *second*)
 ~~~~
@@ -176,7 +176,7 @@ calls, even if they were evaluated at the same time.
 Often this lack of precision is fine (i.e. too small a change to be noticeable)
 but where absolute accuracy is required a time variable should be used.
 
-~~~~ sourceCode
+~~~~ xtlang
 (let ((time (now)))
   (play-note time synth 60 80 *second*)
   (play-note time synth 72 80 *second*))
@@ -188,7 +188,7 @@ incrementing a `time` value between each recursive callback (note that any
 arguments required by the function being called back must also be passed to
 `callback`).
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; This is bad
 (define loop
   (lambda ()
@@ -212,7 +212,7 @@ note `(now)`, by the time the code is evaluated it will already be late: `(now)`
 will have moved on. You should always try to schedule your code execution
 *ahead* of the scheduled time of your tasks.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; This is best (callback happens 4100 samples earlier than new time)
 (define loop
   (lambda (time)

--- a/_docs/overview/using-extempore.md
+++ b/_docs/overview/using-extempore.md
@@ -151,7 +151,9 @@ xtlang global variable of type `double`. If you evaluate this with `Alt+S` or
 One difference from the previous (Scheme) example is that the `extempore`
 compiler now prints a message to the console:
 
+~~~~ sourceCode
     Bound myPI >>> double
+~~~~
 
 Evaluating *xtlang* code will always print a message to the log about the name
 and type of the variables. Also, notice how the string that is echoed back is
@@ -169,7 +171,9 @@ representing the radius of a circle and returns the area of that circle (another
 `double`). It also uses the global variable `myPI` which we evaluated earlier.
 The closure compiled successfully, and the compiler prints
 
+~~~~ sourceCode
     Compiled circle_area >>> [double,double]*
+~~~~
 
 to the log. If there was a problem with the compilation, then the compiler would
 have printed a (hopefully helpful) compile error to the log instead.

--- a/_docs/reference/c-xtlang-interop.md
+++ b/_docs/reference/c-xtlang-interop.md
@@ -117,7 +117,7 @@ Once the shared library is compiled, the only thing to do before it's callable
 from xtlang code is to tell xtlang compiler about the type signature of the
 functions in the library. To do this, we use `bind-lib`.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; libfoo.xtm -- an xtm header for libfoo
 
 ;; load the shared lib
@@ -242,7 +242,7 @@ So now we can just go ahead and turn the signature of `kiss_fft` into a
 `bind-lib` and we're done, right? Something like (remembering that xtlang uses
 `i8*` in place of C's `void` type)
 
-~~~~ sourceCode
+~~~~ xtlang
 (define kissfft (bind-dylib "kiss_fft.dylib"))
 
 (bind-lib kissfft kiss_fft [i8*,kiss_fft_cfg,kiss_fft_cpx*,kiss_fft_cpx*]*)
@@ -340,7 +340,7 @@ number.
 Now, finally, we know all the types we need to call `kiss_fft`. We just need to
 tell the xtlang compiler about them.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; in fft.xtm
 
 (bind-type kiss_fft_cpx <float,float>)

--- a/_docs/reference/concurrency.md
+++ b/_docs/reference/concurrency.md
@@ -28,7 +28,7 @@ Here is a starting example of a Scheme function that mutates a Scheme global
 variable. The function includes a *blocking* sleep---it will `println` then
 sleep for one second, test conditional and repeat.
 
-~~~~ sourceCode
+~~~~ xtlang
 (define global-val 0)
 
 (define my-scm-func
@@ -48,7 +48,7 @@ concurrency occurs within this context using cooperative concurrency. So, for
 example, we can happily run this code concurrently. Eval each of the following
 lines in turn using
 
-~~~~ sourceCode
+~~~~ xtlang
 (set! global-val 0)
 (my-scm-func 'a 10)
 (my-scm-func 'b 10)
@@ -69,13 +69,13 @@ of CPU cores.
 
 You can spawn your own process with a name and a network port like this:
 
-~~~~ sourceCode
+~~~~ xtlang
 (ipc:new "myproc" 7090)
 ~~~~
 
 or you can connect to a remote process like this:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; assuming a host at 192.168.1.1 is running Extempore
 (ipc:connect "192.168.1.1" "myproc" 7099)
 ~~~~
@@ -86,7 +86,7 @@ remote.
 
 You can explicitly call into `my-scm-func` in the primary process like so:
 
-~~~~ sourceCode
+~~~~ xtlang
 (ipc:call "primary" 'my-scm-func 'a 5)
 ~~~~
 
@@ -97,7 +97,7 @@ make this call into primary no matter what scheme process we are currently
 
 We can try to run `my-scm-func` in the *myproc* process as follows:
 
-~~~~ sourceCode
+~~~~ xtlang
 (ipc:call "myproc" 'my-scm-func 'a 5)
 ~~~~
 
@@ -106,7 +106,7 @@ matter) do not exist in the memory space of *myproc*. We can fix that using
 Extempore's IPC infrastructure simply enough by defining both `global-val` and
 `my-scm-func` in *myproc*.
 
-~~~~ sourceCode
+~~~~ xtlang
 (ipc:define "myproc" 'global-val global-val)
 (ipc:define "myproc" 'my-scm-func my-scm-func)
 ~~~~
@@ -119,13 +119,13 @@ was currently bound to in our *connected* process, which in this instance was
 *primary* but could be whatever process our text buffer was connected to. We
 could just as easily have defined a different value into *myproc*, e.g.
 
-~~~~ sourceCode
+~~~~ xtlang
 (ipc:define "myproc" 'global-val 0)
 ~~~~
 
 So, now try evaluating the next four lines one after the other
 
-~~~~ sourceCode
+~~~~ xtlang
 (ipc:define "primary" 'global-val 0)
 (ipc:define "myproc" 'global-val 0)
 (ipc:call "primary" 'my-scm-func 'a 5)
@@ -149,7 +149,7 @@ other. Generally this xtlang code will behave as expected with regards to
 concurrency, i.e. will generally behave as if it were just another Scheme call
 inside the Scheme process. As a trivial example, consider the xtlang function:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func times2
    (lambda (x)
        (* x 2)))
@@ -158,7 +158,7 @@ inside the Scheme process. As a trivial example, consider the xtlang function:
 Compiling this xtlang function automatically creates a Scheme binding with
 exactly same name, which allows us to call it like any other scheme call:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; try evaluating this line
 (times2 4)
 ~~~~
@@ -166,7 +166,7 @@ exactly same name, which allows us to call it like any other scheme call:
 Of course, we can incorporate this Scheme wrapper call into our normal Scheme
 code, for example we can modify the `my-scm-func` from above:
 
-~~~~ sourceCode
+~~~~ xtlang
 (define my-scm-func
   (lambda (name x)
     (println name (ipc:get-process-name) (times2 global-val))
@@ -179,7 +179,7 @@ code, for example we can modify the `my-scm-func` from above:
 and all of our existing examples will work just fine. For example, cooperative
 concurrency as before:
 
-~~~~ sourceCode
+~~~~ xtlang
 (define global-val 0)
 (my-scm-func 'a 10)
 (my-scm-func 'b 10)
@@ -190,7 +190,7 @@ because we have changed its definition. Also note that we need to tell *myproc*
 about `times2` (note that `ipc:bind-func` has a slightly different signature
 from `ipc:define`):
 
-~~~~ sourceCode
+~~~~ xtlang
 (ipc:bind-func "myproc" times2)
 (ipc:define "myproc" 'my-scm-func my-scm-func)
 ~~~~
@@ -198,7 +198,7 @@ from `ipc:define`):
 now we can re-run the same ipc example as earlier (evaluating each line one
 after the other)
 
-~~~~ sourceCode
+~~~~ xtlang
 (ipc:define "primary" 'global-val 0)
 (ipc:define "myproc" 'global-val 0)
 (ipc:call "primary" 'my-scm-func 'a 5)
@@ -221,7 +221,7 @@ every Scheme process).
 
 For example:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func xtlang_inc
   (let ((y 0))
     (lambda (inc)
@@ -241,7 +241,7 @@ performance optimizations etc.
 This also goes for any globally bound xtlang variables. Consider this code for
 example.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-val my_xtlang_global i64 0)
 
 (bind-func get_global
@@ -287,7 +287,7 @@ Here's an xtlang example that completely breaks out of Extempore's "normal
 environment" by managing its own native OS threads using standard fork/join
 semantics.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; sleep for 0-3 seconds
 (bind-func my_os_thread
   (lambda ()

--- a/_docs/reference/docstrings.md
+++ b/_docs/reference/docstrings.md
@@ -7,7 +7,7 @@ javadoc/jsdoc-style markup for documenting individual parameters, return values,
 providing links to other, related functionality, and even examples. Here's an
 example of a closure with a docstring:
 
-```
+~~~~ xtlang
 (bind-func bens_great_function
   "a (one-line) description of the function: this is Ben's great
     function for adding two numbers together
@@ -27,7 +27,7 @@ bens_great_function (well, as long as the numbers are i64).
 @see bens_other_great_function - another great function to check out"
   (lambda (a:i64 b)
     (+ a b)))
-```
+~~~~
 
 The `@param` lines are just for providing docstrings for each argument:
 the names and types of the arguments will be taken from the actual
@@ -36,7 +36,7 @@ one-line string as the docstring.
 
 You can also add docstrings to other (xtlang) things:
 
-```
+~~~~ xtlang
 (bind-val bens_global_variable i32 42
    "the answer to life, the universe and everything
 
@@ -73,7 +73,7 @@ of BenType\*
    (println bt)) ;; prints &lt;BenType: 3 5.200&gt;
 
 @see BenType")
-```
+~~~~
 
 ## Contributing {#contributing}
 

--- a/_docs/reference/memory-management.md
+++ b/_docs/reference/memory-management.md
@@ -29,7 +29,7 @@ any references to them) the memory is automatically freed up for re-use.
 Let's do the most basic memory allocation imaginable: just binding a numerical
 value to a symbol.
 
-~~~~ sourceCode
+~~~~ xtlang
 (define a 5)
 
 (println 'a '= a)  ;; prints a = 5
@@ -44,7 +44,7 @@ and binding a reference to the value in the symbol `a`.
 
 We can redefine the symbol `a` to be some other Scheme object, say, a list.
 
-~~~~ sourceCode
+~~~~ xtlang
 (define a '(1 2 3))
 
 (println 'a '= a)  ;; prints a = (1 2 3)
@@ -160,7 +160,7 @@ references and carries them around in its saddlebags.
 
 Well, that's as clear as mud. Let's have an example.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func simple_stack_alloc
   (lambda ()
     (let ((a 2)
@@ -189,7 +189,7 @@ This 'implicit stack allocation' works for int and float literals, but how about
 aggregate and other higher-order types? In those cases, we call `salloc`
 explicitly.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func double_tuple
   (lambda (a:i64)
     (let ((tup:<i64,i64>* (salloc)))
@@ -222,7 +222,7 @@ signature `[<i64,i64>*,i64]*`).
 
 What happens if we try and dereference this returned pointer?
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func double_tuple_test
   (lambda ()
     (let ((tup (double_tuple 6)))
@@ -241,7 +241,7 @@ What happens if we try and dereference this returned pointer?
 Well, that seems to work OK. What about if we call `double_tuple` again in the
 body of the `let`, ignoring its return value?
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func double_tuple_test2
   (lambda ()
     (let ((tup (double_tuple 6)))
@@ -266,7 +266,7 @@ we have a pointer to in `tup`) have been overwritten.
 
 Finally, consider this example:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func double_tuple_test3
   (lambda ()
     (let ((tup (double_tuple 6))
@@ -320,7 +320,7 @@ up to the length of the region (`region_length`). We'll need to allocate the
 memory for this region, and get a pointer to the start of the region. We can do
 this using `zalloc` inside a `memzone`.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func fill_buffer_memzone
   (lambda ()
     (memzone 100000  ;; size of memzone (in bytes)
@@ -346,7 +346,7 @@ passed.
 Let's try another version of this code `fill_buffer_memzone2`, but with a much
 longer buffer of `i64` values.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func fill_buffer_memzone2
   (lambda ()
     (memzone 100000  ;; size of memzone (in bytes)
@@ -420,7 +420,7 @@ the time---usually the default zone (unless you're in an enclosing `memzone`).
 As an example, let's revisit our 'fill buffer' examples from earlier. With a
 region length of one thousand:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func fill_buffer_closure_zone
   (let ((region_length 1000)
         (int_buf:i64* (zalloc region_length))
@@ -443,7 +443,7 @@ Leaving a leaky zone can be dangerous ... particularly for concurrency
 
 Let's try it again, but with a 'zone size' argument to `bind-func`
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func fill_buffer_closure_zone2 10000 ;; zone size: 10KB
   (let ((region_length 1000)
         (int_buf:i64* (zalloc region_length))
@@ -480,7 +480,7 @@ give you a pointer to some memory on the heap. So, let's revisit the
 for `tup` on the stack went out of scope when the closure returned. If we
 replace the `salloc` with a `halloc`:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func double_tuple_halloc
   (lambda (a:i64)
     (let ((tup:<i64,i64>* (halloc))) ;; halloc instead of salloc
@@ -536,7 +536,7 @@ in a way that's trickier to do in higher-level languages. Remember that memory
 is a finite resource. Don't try and allocate a memory region of 10<sup>15</sup>
 8-byte `i64`:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func fill_massive_buffer
   (lambda ()
     (let ((region_length 1000000000000000)
@@ -588,7 +588,7 @@ The `let` form in xtlang (as in Scheme) is a way of binding or assigning
 variables: giving a name to a particular value. If we want to keep track of the
 number of cats you have, then we can create a variable `num_cats`
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func print_num_cats
   (lambda ()
     (let ((num_cats:i64 4))
@@ -618,7 +618,7 @@ closure `print_num_cats` is called again).
 
 Once a variable exists, we can change its value with `set!`:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func print_num_cats2
   (lambda ()
     (let ((num_cats:i64 4))
@@ -668,7 +668,7 @@ Let's update our code for printing the number of cats to use a pointer to the
 value, rather than the value itself. Notice how the type of `num_cats_ptr` is
 `i64*` (a pointer to an `i64`) rather than just an `i64` like it was before.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func print_num_cats3
   (lambda ()
     (let ((num_cats_ptr:i64* (zalloc)))
@@ -727,7 +727,7 @@ index means in the next section) and a value. The value must be of the right
 type: e.g. if the pointer is a pointer to a double (a `double*`) then the value
 must be a `double`.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func print_num_cats4
   (lambda ()
     (let ((num_cats_ptr:i64* (zalloc)))
@@ -766,7 +766,7 @@ in memory, in which we can store *lots* of values. Say we want to be able to
 determine the mean (average) of 3 numbers. One way to do this is to store each
 of the different numbers with its own name.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func mean1
   (lambda ()
     (let ((num1:double 4.5)
@@ -787,7 +787,7 @@ mean of 5, 20 or one million values. What we really want is a way to give *one*
 name to all the values we're interested in, rather than having to refer to all
 the values by name individually. And to do that, we can use a pointer.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func mean2
   (lambda ()
     (let ((num_ptr:double* (zalloc 3)))
@@ -822,7 +822,7 @@ There is a helpful function called `pfill!` for filling multiple values into
 memory (multiple calls to `pset!`) as we did in the above example. Rewriting
 `mean2` to use `pfill!`:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func mean3
   (lambda ()
     (let ((num_ptr:double* (zalloc 3)))
@@ -843,7 +843,7 @@ Finally, one more useful way to fill values into a chunk of memory is using a
 index for the loop. This function allocates enough memory for 5 `i64` values,
 and just fills it with ascending numbers:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func ptr_loop
   (lambda ()
     (let ((num_ptr:i64* (zalloc 5))
@@ -882,7 +882,7 @@ would have the type signature `<i64,double>`. Getting and setting tuple elements
 is done with `tref` and `tset!` respectively, which both work exactly like
 `pref=/=pset!` except the first argument has to be a pointer to a tuple.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func print_tuples
   (lambda ()
     ;; step 1: allocate memory for 2 tuples

--- a/_docs/reference/new/advanced-functions.md
+++ b/_docs/reference/new/advanced-functions.md
@@ -17,7 +17,7 @@ In xtlang, closure types are indicated by square brackets ([]), with the first e
 
 Closures can return any valid type including another closure:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func return-fun:[[i64,i64]*,i64]*
   (lambda (inc)
     (lambda (num) (+ num inc))))
@@ -25,7 +25,7 @@ Closures can return any valid type including another closure:
 
 Most of the time you will not need to define the function type as Extempore's type inference engine is pretty good at working it out for you:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; Extempore works out that `inc` is an i64 because `1` is an i64
 (bind-func simple-inc
   (lambda (inc)
@@ -43,7 +43,7 @@ Often defining the types for one or more parameters will be sufficient and you w
 
 There will be many situations where you want to use the same function on different types. This is very easy in xtlang as you just write a new function with the desired type:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func sum:[i64,i64,i64]*
   (lambda (x y)
     (+ x y)))
@@ -55,7 +55,7 @@ There will be many situations where you want to use the same function on differe
 
 As long as the function type is different each time, you can do this as many times as makes sense. You can even overload functions based upon the return type, which can be occasionally useful:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func sum:[float,i64,i64]*
   (lambda (x y)
     (convert (+ x y) )))
@@ -74,7 +74,7 @@ As long as the function type is different each time, you can do this as many tim
 
 In a previous chapter we noted that you can define an environment for a closure as part of its definition:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func my-closure
   (let ((a:i32 6))
     (lambda ()
@@ -86,7 +86,7 @@ In a previous chapter we noted that you can define an environment for a closure 
 
 It is also possible in xtlang to access that environment directly using a dot operator `closure_name.slot_name:type`. E.g. `(f.a:i32)` to access the value and `(f.a:i32 565)` to set it. So let's see how this works with `my-closure`:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (my-closure.a:i32 8))
 ($ (my-closure)) ;; this should print 8.
 
@@ -95,7 +95,7 @@ It is also possible in xtlang to access that environment directly using a dot op
 
 This will also work for anonymous closures:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func my-closure
   (lambda (x:i64)
     (lambda (y) (+ x y))))
@@ -112,7 +112,7 @@ This will also work for anonymous closures:
 
 And of course the closure's environment can also contain functions (or closures) of its own which you can also access:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func my-closure-with-func
   (let ((f (lambda (x)
              (+ x 1))))

--- a/_docs/reference/new/advanced-types.md
+++ b/_docs/reference/new/advanced-types.md
@@ -41,7 +41,7 @@ So for example given the array `a:|4,double|*` we can access it in serial order 
 
 or use it in a function like this:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func get-member2
   (lambda (v:|4,i64|*)
     (aref v 2)))
@@ -51,7 +51,7 @@ But `(aref a 4)` won't compile as `a` only has 4 elements.
 
 You can also get the memory location of a member array using `aref-ptr`:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func get-member2:[i64*,|4,i64|*]*
   (lambda (v:|4,i64|*)
     (aref-ptr v 2)))
@@ -72,7 +72,7 @@ So for example given the array `a:|4,double|*` we can set each value to 0 like t
 
 and we can use it in a function like this:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; Set every member of the array to 0
 (bind-func zero-set
   (lambda (v:|4,i64|*)
@@ -88,7 +88,7 @@ We could also do the same thing more succinctly using `afill!`:
 
 and redefining the function above we get this:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; Set every member of the array to 0
 (bind-func zero-set
   (lambda (v:|4,i64|*)
@@ -97,7 +97,7 @@ and redefining the function above we get this:
 
 You can also initialize arrays directly using array_ref:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; Initialize and create an array
 (bind-func test-array
   (lambda ()
@@ -147,7 +147,7 @@ There are two ways to define a custom type: `bind-type` and `bind-alias`.
 
 Examples:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-alias my_type_1 <i64,double>)
 (bind-type my_type_2 <float,[i64,i32]*,|3,double|*>)
 ~~~~
@@ -160,7 +160,7 @@ tricky debugging.
 As an example, let's make a 2D 'point' type, and a function for calculating the
 euclidean distance between two points.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-type point <double,double>)
 
 (bind-func euclid_distance
@@ -176,7 +176,7 @@ euclidean distance between two points.
 To test this out, we can check the diagonal length of the unit square, which
 should be `sqrt(2) = 1.41`
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func test_unit_square_diagonal
   (lambda ()
     (let ((bot_left:point* (alloc))
@@ -196,7 +196,7 @@ Now, what happens if we change this testing example to make `top_right` and
 `bot_left` just plain tuples of type `<double,double>` instead of being our new
 `point` type.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func test_unit_square_diagonal_2
   (lambda ()
     (let ((bot_left:<double,double>* (alloc))
@@ -243,7 +243,7 @@ While Algebraic Data Types work, they are currently slow to compile and have bad
 
 Imagine that you have a shape type that can either be a circle, or a square: In Extempore we could create a type for this as follows:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; load the adt library
 (sys:load "libs/base/adt.xtm")
 
@@ -258,7 +258,7 @@ Note that ADTs are not part of the core library so you have to load the ADT libr
 
 Now that we've defined this ADT what can we do with it. Lets create a simple function that returns a circle:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func make-shape:[Shape*,point,double]*
   (lambda (pos:point rad:double)
     (Circle pos rad)))
@@ -271,24 +271,24 @@ There are two things to note here:
 
 Now that we have a `Shape` type, how do we use it? Let's create a function that prints a shape:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func print-shape
   (lambda (shape:Shape*)
-    (Circle$ shape (pos rad) 
+    (Circle$ shape (pos rad)
              (println "x: %f, y: %f, Radius: %f" (tref pos 0) (tref pos 1) rad)
              (Rect$ shape (point1 point2)
-                    (println "x1: %f, y1: %f\nx2: %f, y2: %f" 
+                    (println "x1: %f, y1: %f\nx2: %f, y2: %f"
                              (tref point1 0) (tref point1 1)
                              (tref point2 0) (tref point2 1))
                     void))))
 ~~~~
 
-The important functions here are `Circle$` and `Rect$`. So where did they come from? When you create a new ADT with `bind-data` the xtlang compiler creates a macro for each sub-type that allows you to access the data. The macro name is the name of the sub-type followed by the '$' sign. So for the Shape type we have the macros: `Circle$` and `Rect$`. 
+The important functions here are `Circle$` and `Rect$`. So where did they come from? When you create a new ADT with `bind-data` the xtlang compiler creates a macro for each sub-type that allows you to access the data. The macro name is the name of the sub-type followed by the '$' sign. So for the Shape type we have the macros: `Circle$` and `Rect$`.
 
 So let's examine the `Circle$` macro more closely. This takes four arguments:
 
 1. A variable of type `Shape`.
-1. Two variables inside brackets: `pos` and `rad`. These variables are the two member variables for the `Rect` sub-type in the same order that are declared in the `bind-data` declaration above. 
+1. Two variables inside brackets: `pos` and `rad`. These variables are the two member variables for the `Rect` sub-type in the same order that are declared in the `bind-data` declaration above.
   1. `pos` has type `point`.
   1. `rad` has type `double`.
 1. A form of type `[!a]*`. Where `!a` just means that this function can return any type.

--- a/_docs/reference/new/basics.md
+++ b/_docs/reference/new/basics.md
@@ -10,7 +10,7 @@ In this chapter we'll start you slowly by showing you some of the basics of prog
 
 Let's beging with everyone's favourite first program:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (println "Hello World!"))
 ~~~~
 
@@ -23,7 +23,7 @@ The $ form is used to tell Extempore that the code you are sending it is XTLang 
 
 `println` can do more than just print strings:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (println 4)) -- prints 4 to the command line.
 ($ (println 3 "+" 4 "=" (+ 3 4)))
 ~~~~

--- a/_docs/reference/new/closures.md
+++ b/_docs/reference/new/closures.md
@@ -10,14 +10,14 @@ Like Scheme xtlang is a functional language. As you might expect, that functions
 
 In xtlang functions are defined using `lambda`:
 
-~~~~ sourceCode
+~~~~ xtlang
 (lambda (x)
   (+ x 1))
 ~~~~
 
 The function above takes a single variable `x` and adds `1` to it. The result of the expression ```(+ x 1)``` is returned by the function. Functions in xtlang _always_ return a value. The value returned is the last expression in the function:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; A function that always returns 1
 (lambda (x)
   1))
@@ -25,7 +25,7 @@ The function above takes a single variable `x` and adds `1` to it. The result of
 
 When you evaluated the code above you probably saw something like the following: ``#<<CLOSURE: 0x123543345>`` appear in your editor. This message telling you that you created a function. If want to be able to call this function then we need to **bind** it to a function name using `bind-func`:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func add1
   (lambda (x)
     (+ x 1)))
@@ -33,14 +33,14 @@ When you evaluated the code above you probably saw something like the following:
 
 now we can call this function like so (remembering to use the `$` form as we're calling an xtlang function):
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (add1 4)) ;; this returns 5
 ($ (add1 5)) ;; this returns 6
 ~~~~
 
 and we can call this function from other functions as well:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func advanced-math
   (lambda (y)
     (* y (add1 y))))
@@ -50,7 +50,7 @@ and we can call this function from other functions as well:
 
 Like Scheme you can define local variables using the `let` form:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func boring
   (lambda ()
     (let ((x 5)
@@ -62,7 +62,7 @@ Like Scheme you can define local variables using the `let` form:
 
 You can also define local functions this way:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func adder
   (lambda (x)
     (let ((f (lambda (a)
@@ -74,7 +74,7 @@ You can also define local functions this way:
 
 Once you've created a variable you can change it's value using `set!`:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func silly-func
   (lambda (y)
     (let ((i 0))
@@ -92,14 +92,14 @@ If you have a Scheme background it is worth noting that xtlang does not need the
 
 Local variables live only while they are in scope. As soon as they leave scope the variable can no longer be accessed.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func scope-func
   (lambda (y)               ;; y is in scope
     (let ((i 0))            ;; i and y are in scope
       (let (v (+ i 1))      ;; v, i and y are in scope
         (set! i (+ v 1)))   ;; v, i and y are in scope
       (set! i (+ y v)))     ;; i and y are in scope.
-                            ;;   You can no longer access `i` 
+                            ;;   You can no longer access `i`
     (+ y 1)))               ;; y is in scope.
                             ;;   You can no longer access `i` or `y`
 ~~~~
@@ -118,7 +118,7 @@ A program when it is running has two blocks of memory: the stack, and the heap. 
 
 Similarly whenever you allocate local variables in a let block, those variables are pushed onto the stack - when your code leaves the block that data is popped off the stack.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func f
   (lambda (x)
     (+ (g x) x)))
@@ -144,7 +144,7 @@ So let's step through what happens when we call ```($ (f 4))```:
 
 A recursive function is a function that calls itself:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func adder
   (lambda (x)
     (if (<= x 0) 0
@@ -171,7 +171,7 @@ For more information on recursion and how to use it see the Scheme tutorial [Whe
 
 Every time your function recurses it uses a little more stack space. While this is fine with small functions, with larger functions you can quickly run out of stack space. If your program uses up the stack then Extempore will crash:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; Don't run this!!
 ($ (println(adder 1000000)))
 ~~~~
@@ -182,7 +182,7 @@ Fortunately it is possible to rewrite our function so it doesn't use any stack s
 
 A function is tail recursive when the recursive call is the last thing executed by the function:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func boring
   (lambda (x)
     (if (<= x 0) 0
@@ -217,7 +217,7 @@ In other words when a tail recursive function stops recursing there is no more w
 
 Resulting in extremely fast code that will never abuse your stack [fn:: The resulting code is equivalent to a C while loop]. So how would we take advantage of this for the `adder` function above. The trick to making that function tail recursive is to realize that we need to pass the answer in as a second parameter:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func adder-tail
   (lambda (x res)
     (if (<= x 0) res
@@ -232,7 +232,7 @@ Resulting in extremely fast code that will never abuse your stack [fn:: The resu
 
 This is a slightly ugly interface, so we wrap adder-tail in another function:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func better-adder
   (lambda (x)
     (let ((fn (lambda (x res)
@@ -247,7 +247,7 @@ And now we can run ```($ (println(better-adder 100000000)))``` with absolutely n
 
 Like with Scheme, all functions in xtlang are lexical closures. This means that any variable referenced in the scope of the function is captured along with the function, even if that variable was not passed in as an argument.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; this function returns another function that has access to the original x parameter
 (bind-func test-closure
   (lambda (x)
@@ -260,7 +260,7 @@ The inner function has access to all the variables defined in the outer function
 
 We can also do this:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func test-closure2
   (let ((x 4))
     (lambda (y)
@@ -270,4 +270,3 @@ We can also do this:
 ~~~~
 
 By using the `let` form before we define the function bound to `test-closure`, we create a closure that contains the variable x the function can access (or to use the correct terminology, it _closes over_ `x`).
-

--- a/_docs/reference/new/control-logic.md
+++ b/_docs/reference/new/control-logic.md
@@ -12,20 +12,20 @@ In this chapter we'll discuss some of your options in xtlang for control logic a
 
 The `begin` form allows you to combine multiple expressions. The final expression in the block is the return value (all other return values are ignored.)
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; This won't compile
 ($ ((+ 3 5)
     (- 3 4)))
 
 ;; This will and returns -1
-($ (begin 
+($ (begin
     (+ 3 5)  ;; return value will be ignored.
     (-3 4)))
 ~~~~
 
 This is usually most useful for sequencing expressions with side effects. For example:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (begin
      (println "line 1")
      (println "line 2")))
@@ -33,7 +33,7 @@ This is usually most useful for sequencing expressions with side effects. For ex
 
 Or if you wanted to add logging to a function:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; Dumb Logging Code
 (bind-func log-adder
   (lambda (x:i64 y:i64)
@@ -52,7 +52,7 @@ Predicates are functions that either return #t, or #f. These are mostly self-exp
 
 While predicates in xtlang work with many different types, they expect both types to be identical. So for example while both `(< 3 5)` and `(< 3.5 5.6)` are acceptable, `(< 3.5 5)` will throw a compiler error. If you need to compare two variables of different types then you will need to coerce one of them using either `convert`, or one of the more specific coercion functions. When doing this always be careful to coerce to a datatype that can hold more information, unless you _really_ know what you're doing. For example:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (= 3.1 (convert 3))) ;; returns #f
 
 ($ (= (convert 3.1) 3)) ;; returns #t, NOT #f
@@ -60,7 +60,7 @@ While predicates in xtlang work with many different types, they expect both type
 
 The second expression results in a subtle bug. If you want to 'demote' a variable to a datatype that holds less information, always be explicit about how you want the information to be removed. E.g. if converting a float to an integer, use `ceil`, `floor`, `round`, etc to make explict the type of conversion you are expecting:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (= (convert (abs 2.9)) 3)) ;; returns #t, which is what we are expecting.
 ~~~~
 
@@ -69,7 +69,7 @@ The second expression results in a subtle bug. If you want to 'demote' a variabl
 + __Function:__ `>`
 + __Supported Types:__ `i32`, `i64`, `float`, `double`, `i8`, pointers?
 
-~~~~ source Code
+~~~~ xtlang
 ($ (> 3 4))  ;; #f
 ($ (> 4 3))  ;; #t
 ~~~~
@@ -79,7 +79,7 @@ The second expression results in a subtle bug. If you want to 'demote' a variabl
 + __Function:__ `>=`
 + __Supported Types:__ `i32`, `i64`, `float`, `double`, `i8`, pointers?
 
-~~~~ source Code
+~~~~ xtlang
 ($ (>= 3 4))  ;; #f
 ($ (>= 4 3))  ;; #t
 ($ (>= 4 4))  ;; #t
@@ -91,7 +91,7 @@ The second expression results in a subtle bug. If you want to 'demote' a variabl
 + __Function:__ `<`
 + __Supported Types:__ `i32`, `i64`, `float`, `double`, `i8`, pointers?
 
-~~~~ source Code
+~~~~ xtlang
 ($ (< 3 4))  ;; #t
 ($ (< 4 3))  ;; #f
 ~~~~
@@ -101,7 +101,7 @@ The second expression results in a subtle bug. If you want to 'demote' a variabl
 + __Function:__ `<=`
 + __Supported Types:__ `i32`, `i64`, `float`, `double`, `i8`, pointers?
 
-~~~~ source Code
+~~~~ xtlang
 ($ (<= 3 4))  ;; #t
 ($ (<= 4 3))  ;; #f
 ($ (<= 4 4))  ;; #t
@@ -112,7 +112,7 @@ The second expression results in a subtle bug. If you want to 'demote' a variabl
 + __Function:__ `=`
 + __Supported Types:__ `i32`, `i64`, `float`, `double`, `i8`, pointers?
 
-~~~~ source Code
+~~~~ xtlang
 ($ (= 3 4))  ;; #f
 ($ (= 4 4))  ;; #t
 ~~~~
@@ -122,7 +122,7 @@ The second expression results in a subtle bug. If you want to 'demote' a variabl
 + __Function:__ `<>`
 + __Supported Types:__ `i32`, `i64`, `float`, `double`, `i8`, pointers?
 
-~~~~ source Code
+~~~~ xtlang
 ($ (<> 3 4))  ;; #t
 ($ (<> 4 4))  ;; #f
 ~~~~
@@ -132,7 +132,7 @@ The second expression results in a subtle bug. If you want to 'demote' a variabl
 + __Function:__ `null?`
 + __Supported Types:__ pointers?
 
-~~~~ source Code
+~~~~ xtlang
 TODO
 ~~~~
 
@@ -145,7 +145,7 @@ Returns true if the value passed to it is not a number (e.g. infinity).
 
 Might need to be implemented...
 
-~~~~ source Code
+~~~~ xtlang
 TODO
 ~~~~
 
@@ -156,7 +156,7 @@ Takes two predicates and applies 'OR' to their values.
 + __Function:__ `or`
 + __Supported Types:__ `i1`
 
-~~~~ source Code
+~~~~ xtlang
 ($ (or #t #f )) ;; #t
 ($ (or (< 3 4) (= 3 4))) ;; #t
 ~~~~
@@ -168,7 +168,7 @@ Takes two predicates and applies 'OR' to their values.
 + __Function:__ `and`
 + __Supported Types:__ `i1`
 
-~~~~ source Code
+~~~~ xtlang
 ($ (and #t #f )) ;; #f
 ($ (and #t #t )) ;; #t
 ($ (and (< 3 4) (= 3 4))) ;; #f
@@ -181,7 +181,7 @@ Takes a predicate and inverts its value.
 + __Function:__ `not`
 + __Supported Types:__ `i1`
 
-~~~~ source Code
+~~~~ xtlang
 ($ (not #t )) ;; #f
 ($ (not #f )) ;; #t
 ($ (not (< 3 4)) ;; #f
@@ -197,7 +197,7 @@ You have already seen `if` used already, and so we'll just formally describe her
 1. The branch to evaluate if the comparison is true.
 1. The branch to evaluate if the comparison is false (e.g. the 'else' statement). This expression must have the same return type as the other branch. This return type can of course be `void`.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func simple-if
   (lambda (x:i1)
     (if (x)
@@ -210,7 +210,7 @@ You have already seen `if` used already, and so we'll just formally describe her
 
 Remember that both parts of the if statement must have the same return type:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; This won't compile as 5:i64 and 6.5:double
 (bind-func return-if
   (lambda (x:i1)
@@ -226,7 +226,7 @@ Remember that both parts of the if statement must have the same return type:
 
 Where `if` only allows two branches, `cond` supports multiple branches, with an optional default. It takes the form:
 
-~~~~ sourceCode
+~~~~ xtlang
 (cond
  ((comparison-1) (branch-1))   ;; this is the first branch
  ((comparison-2) (branch-2))   ;; this is the second branch
@@ -242,7 +242,7 @@ Each branch must return the same type, otherwise the compiler will complain (the
 
 So let's look at a couple of examples. First a version that returns default:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (cond
     ((= 5 4) (println "never reached"))
     ((= 4 4) (println "4 equals 4"))
@@ -251,7 +251,7 @@ So let's look at a couple of examples. First a version that returns default:
 
 If we were to modify this code slightly then nothing will happen:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; Nothing will be printed to the terminal
 ($ (cond
     ((= 5 4) (println "never reached"))
@@ -265,7 +265,7 @@ If your return type is void then not providing an `else` branch often makes sens
 
 If we add and `else` statement we can add defaults:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; prints 7 to the terminal
 ($ (println
      (cond
@@ -283,7 +283,7 @@ If we add and `else` statement we can add defaults:
 1. An expression, or function, that returns true or false (e.g. an `i1` type).
 1. The expression to evaluate while the predicate is `true`.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func simple-while
   (lambda (x:i64)
     (let ((count 0))
@@ -312,37 +312,37 @@ The parameters block consists of:
 2. __REQUIRED:__ The number of times to loop.
 3. __OPTIONAL:__ The starting value for the variable. The default for this value is `0`.
 
-~~~~ sourceCode
-;; defining i so we can use it in dotimes. 
+~~~~ xtlang
+;; defining i so we can use it in dotimes.
 ;; Note that the value we set it to is unimportant.
-($ (let ((i 0)) 
+($ (let ((i 0))
   (dotimes (i 2) (println i "iteration")))) ;; i is set to the default of 0
 ~~~~
 
 will print:
-~~~~ sourceCode
+~~~~ xtlang
 0 iteration
 1 iteration
 ~~~~
 
 The value that we set `i` to in the `let` statement is unimportant. The code below will give us the same output:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; Doesn't matter what we set i to.
-($ (let ((i 1000000)) 
+($ (let ((i 1000000))
   (dotimes (i 2) (println i "iteration")))) ;; i is set to the default of 0
 ~~~~
 
 If we want to change the value that our counter starts on then we can do the following:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (let ((i 0)) ;; again the value here is unimportant
   (dotimes (i 2 1) (println i "iteration"))))
 ~~~~
 
 will print:
 
-~~~~ sourceCode
+~~~~ xtlang
 1 iteration
 2 iteration
 ~~~~
@@ -351,7 +351,7 @@ will print:
 
 Sometimes using a let statement in this way can be a little unwieldy and so `doloop` is provided as syntatic sugar for dotimes. Whenever you use `doloop` the compiler automatically creates the let-binding for your "counter" variable and creates a `dotimes` loop for you:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (doloop (i 2) (println i "iteration")))
 
 ;; this is identical to the doloop code above.
@@ -361,7 +361,7 @@ Sometimes using a let statement in this way can be a little unwieldy and so `dol
 
 __WARNING:__ While doloop is convenient, it can make your code inefficient:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; inner loops
 (doloop (i inum)
   (doloop (j jnum)

--- a/_docs/reference/new/generics.md
+++ b/_docs/reference/new/generics.md
@@ -10,7 +10,7 @@ Add something about alloc/zalloc etc with generics.
 
 In an earlier chapter we saw how you could overload functions so that they could handle different types appropriately:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func sum:[i64,i64,i64]*
   (lambda (x y)
     (+ x y) ))
@@ -28,14 +28,14 @@ NOTE: Currently the generics implementation in xtlang has slow compile times. Th
 
 When writing a generic function we use generic types, where a generic type is a placeholder for our eventual concrete type. We write a generic type using `!`. So for example:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func gsum:[!a,!a,!a]*
   (lambda (x y) (+ x y)))
 ~~~~
 
 This function can take any type, the only restriction is that both parameters and the return type _must share that type_. For example:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (gsum 3 4)) ;; OK
 ($ (gsum 3.4 5.3)) ;; OK
 
@@ -46,7 +46,7 @@ This function can take any type, the only restriction is that both parameters an
 
 We could even make this function even more generic by using convert [fn::in real code this particular example is best avoided. It's usually better to explicitly cast in this situations to prevent unexpected errors]:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func rgsum:[!b,!a,!a]*
   (lambda (x y) (convert (+ x y))))
 
@@ -66,7 +66,7 @@ but the following will result in compiler errors:
 
 We can also create functions that mix abstract and concrete types:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func my-func:[i64,!a,!a]*
   (lambda (x y) (convert (+ x y))))
 
@@ -76,7 +76,7 @@ We can also create functions that mix abstract and concrete types:
 
 Returning to our `gsum` function - what happens if we pass in a type that is not supported by the function `+`?
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (gsum 'c' 'd')) ;; This won't compile
 ~~~~
 
@@ -91,7 +91,7 @@ When we create a generic function the compiler doesn't actually generate a funct
 
 So for example:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; No functions are generated when you evaluate this
 (bind-func gen-sum:[!a,!a,!a]
   (lambda x y) (+ x y))
@@ -99,7 +99,7 @@ So for example:
 
 no functions have been compiled yet. Let's call gen-sum with a concrete i64 type: `($ (gen-sum 3 4))`. The compiler looks to see if the function `gen-sum:[i64,i64,i64]*` exists. It can't find it, so now it uses the `gen-sum` _template_ to compile it. Once `gen-sum:[i64,i64,i64]*` has been compiled, the call can be evaluated.
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (gen-sum 3 4)) ;; This concrete instance has already been compiled.
 
 ($ (gen-sum 3.3 4.4)) ;; This concrete instance needs to be compiled first before we can use it
@@ -109,9 +109,9 @@ This means that the first time you call a generic function with a new type signa
 
 This means that generic functions aren't quite like concrete functions:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; the compiler will complain that it cannot find 'summy'
-(bind-func sumf:[i64,i64,i64]* 
+(bind-func sumf:[i64,i64,i64]*
   (lambda (x y) (summy x y)))
 
 ;; the compiler has no problems with this
@@ -128,7 +128,7 @@ The compiler has no problem with you referencing undefined functions and variabl
 
 Let's suppose we want to create a list, but we don't care what the list contains:
 
-~~~~ sourceCode
+~~~~ xtlang
 (sys:load "libs/base/adt.xtm")
 
 (bind-data MyList{!a}
@@ -138,7 +138,7 @@ Let's suppose we want to create a list, but we don't care what the list contains
 
 Note that this is exactly like an ADT with concrete types, but instead we're specifying our abstract type using `!a`. Now let's do some useful with this list. First of all we need to be able to see what's in a list:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func toString_help:[String*,MyList{!a}*,String*]*
   (lambda (lst s)
     (MyCons$ lst (x xs)
@@ -169,7 +169,7 @@ Now let's do something a little bit more exciting, we're going to write a `fmap`
 
 A `fmap` function is a higher order function that allows us to apply a function to every element in our list. So for example:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (map (lambda (x) (+ x 3)) a-list)) ;; this will add 3 to every member of a-list
 ~~~~
 
@@ -183,7 +183,7 @@ In other words we take a list of type `MyList{!a}`, a function of type `[!b,!a]*
 
 So let's write this function:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func fmap:[MyList{!b}*,[!b,!a]*,MyList{!a}*]*
   (lambda (f lst)
     (MyCons$ lst (x xs) (MyCons (f x) (fmap f xs)) (MyNil))))
@@ -196,7 +196,7 @@ This allows us to very succintly write a library of generic data types with usef
 
 One more note about generics and complex data types. You can of course mix concrete and generic types in your type definitions:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-data EitherT{!a}
            (LeftT String)
            (RightT !a))
@@ -212,7 +212,7 @@ Often when we're writing a function we want it to be generic, but not too generi
 
 One thing that we can do is use a type constraint:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func square:[!a,!a]* -> (lambda (ret x) (t:number? x))
   (lambda (x)
     (* x x)))
@@ -221,7 +221,7 @@ One thing that we can do is use a type constraint:
 The function that comes after the `->` is the constraint. Let's look at it a bit more closely:
 `(lambda (ret x) (t:number? x))`. When you call a generic function with types that the compiler hasn't seen before, the compiler will call this constraint to see if this function can be generalized to the new type. Let's look at this in operation:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (square 4))
 
 ;; the compiler hasn't seen square:[i64,i64]* before
@@ -244,7 +244,7 @@ The function that comes after the `->` is the constraint. Let's look at it a bit
 
 ($ (square 'c'))
 ;; square:[i8,i8]* needs to be compiled so the constraint is checked
-;; t:number? returns #f when it is passed an i8 (or character) so compilation fails 
+;; t:number? returns #f when it is passed an i8 (or character) so compilation fails
 ;; and we get the following error:
 
 Constraint Error square failed constraint (lambda (ret x) (t:number? x))
@@ -254,7 +254,7 @@ ast: (square (String##15 "c"))
 
 So our constraint is a predicate which is passed type information and returns true or false. And we can do this for other functions. Here's gSum from earlier:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func gSum:[!a,!a,!a]* -> (lambda (ret x y) (t:number? x))
   (lambda (x y)
     (+ x y)))
@@ -266,7 +266,7 @@ So our constraint is a predicate which is passed type information and returns tr
 
 And we can make it even more generic (note this is only for the sake of having an example. This would be a bad idea in practice):
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func vgSum:[!b,!a,!b]* -> (lambda (ret x y) (and (t:number? x) (t:number? y)))
   (lambda (x y)
     (+ (convert x) (convert y))))
@@ -300,7 +300,7 @@ Currently the type predicates are still a work in progress. But soon you will be
 
 Let's say that we have an overloaded function `sqr`:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; define two sqr polys (i32 and i64)
 (bind-func sqr (lambda (x:i32) (* x x)))
 (bind-func sqr (lambda (x:i64) (* x x)))
@@ -308,7 +308,7 @@ Let's say that we have an overloaded function `sqr`:
 
 and we want to write a generic function that works for any type that supports this function. We can do this using the `t:poly-exists?` function:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func sqr2:[!a,!a]* -> (lambda (r x) (t:poly-exists? 'sqr `(,x ,x)))
   (lambda (x)
     (sqr (sqr x))))
@@ -320,7 +320,7 @@ t:poly-exists? takes two parameters. A symbol or string for the function name an
 
 When the compiler tries to find the function that matches your call it starts by looking for the most specific match. So if you call `(my-func 3 4)` it will begin by looking for a compiled function with the signature `my-func:[i64,i64,i64]*`. If it can't find a matching function it will then try to generate it using any generic functions that it knows about. We can use this fact, along with constraints, to build functions that are overloaded based upon the type of the parameters:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func silly-func:[!a,!a]* -> (lambda (ret x) (t:integer? x))
   (lambda (x)
     (* x x)))
@@ -336,4 +336,3 @@ When the compiler tries to find the function that matches your call it starts by
 ~~~~
 
 So here we have a function that will square integers (`i8`,`i16`,`i32`,`i64`), get the square root of floating point types (`float`,`double`) and to otherwise print the address of a pointer type.
-

--- a/_docs/reference/new/intro-types.md
+++ b/_docs/reference/new/intro-types.md
@@ -11,7 +11,7 @@ define the types of all the variables that you are using. If you do not define
 the variables properly then the compiler will reject it and give you a
 (hopefully) helpful message about what needs to be fixed.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func will-not-compile
   (lambda (x y)
     (+ x y)))
@@ -21,7 +21,7 @@ If you try to compile the source code above you will get an error as the
 compiler has no way of knowing whether x and y should be integers, floats, or
 doubles. Instead we need to define their types using type annotations:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func will-compile
   (lambda (x:i32 y:i32)
     (+ x y)))
@@ -31,7 +31,7 @@ It would be tedious if you had to provide type annotations for every variable.
 Fortunately Extempore will always infer the correct type for a type if it has
 enough information:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func will-compile
   (lambda (x:i32 y)
     (+ x y)))
@@ -41,7 +41,7 @@ So what about those situations where you have two variables of different types
 that need to be combined? XTLang provides the ``convert`` function for these
 situations:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func will-compile
   (lambda (x:i32 y:float)
     (+ x (convert y))))
@@ -70,7 +70,7 @@ integer type with a a size of 1 bit: -   `i1` (boolean)
 
 '0' represents 'False' and '1' represents 'True'.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-val true i1 1)
 (bind-val false i1 0)
 ~~~~
@@ -80,7 +80,7 @@ integer type with a a size of 1 bit: -   `i1` (boolean)
 XTLang doesn't have an explicit character type. Instead characters are stored
 using an integer type that has the size of 1 byte, or 8 bits: -   `i8` (char)
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-val ch i8 'c')
 ~~~~
 
@@ -99,7 +99,7 @@ XTLang only supports signed integers. XTLang supports the following sizes of int
 By default all integers in XTLang are 64 bit. Which means you can write the
 following code without the compiler complaining:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func very-simple-func
   (lambda ()
   34))
@@ -110,7 +110,7 @@ as the compiler knows that 34 should be treated as a type of ``i64``.
 Note that the compiler will only treat 34 as a type of i64 if there is no
 conflicting type information. In this code 34 is treated as an i32:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func very-simple-func
   (lambda (x:i32)
     (+ x 34)))
@@ -127,7 +127,7 @@ There are two sizes of floating point number in XTLang:
 
 Float literals in xtlang code (e.g. `4.2`) are interpreted as `double`:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func very-simple-func2
   (lambda ()
   34.3))
@@ -135,7 +135,7 @@ Float literals in xtlang code (e.g. `4.2`) are interpreted as `double`:
 
 unless the type signatures suggest otherwise:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func very-simple-func
   (lambda (x:float)
     (+ x 34.3)))
@@ -167,7 +167,7 @@ You can get the memory location for a value using pref-ptr:
 
 If you have a memory pointer you can access the value contained within it by using `pref`. `pref` takes two values: a memory pointer and an index.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func get-val
   (lambda (a:i64*)
     (printf "%p" (pref a 0))))
@@ -175,7 +175,7 @@ If you have a memory pointer you can access the value contained within it by usi
 
 In this example we are accessing the `i64` value stored at t  he memory location contained in `a`. We could also access the value in the memory locations that come after `a`. For example:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func get-val-2-after
   (lambda (a:i64*)
     (printf "%p" (pref a 2))))
@@ -184,4 +184,3 @@ In this example we are accessing the `i64` value stored at t  he memory location
 This function is accessing the value in the location two elements *after* `a`. Don't worry if this isn't clear, we will discuss this in greater detail in future chapters. For the moment it is enough that you understand what a pointer is, and that you can recognize the type.
 
 [fn:: If you're a C programmer you're probably wondering about pointer arithmetic. Extempore always increments by the number of bytes used to store your type. E.g. for an i32 it will always increment by four bytes at a time, while for an i64 it will increment by 8 bytes.]
-

--- a/_docs/reference/new/strings.md
+++ b/_docs/reference/new/strings.md
@@ -8,10 +8,10 @@ In this chapter we will introduce strings and the functions available to manipul
 
 Strings in xtlang are immutable. Whenever you call a function that manipulates a string it will return a new string leaving the original string unchanged:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (let ((str1 (String "hello world"))
          (str2 (substring str 0 5)))
-        (begin 
+        (begin
             (println str1)  ;; outputs 'hello world'
             (println str2)))) ;; outputs 'hello'
 ~~~~
@@ -34,20 +34,20 @@ Hopefully this state of affairs will be improved in the future, but for the mome
 
 Strings are creating using the `String` function:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (String "My First String))
 
 (bind-val my-string String "My String")
 
 ;; you can also create a new string from an old one. This creates a copy of the original string.
-($ (String (String "hello"))) 
+($ (String (String "hello")))
 ~~~~
 
 You can also use `Str` as an alias for `String` if you prefer.
 
 Strings can be created from other types using the `toString function:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (toString 4))
 
 (bind-val my-string-num2 String* (toString 4))
@@ -57,7 +57,7 @@ Strings can be created from other types using the `toString function:
 
 To get the length of a string use length:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (length (String "hello"))) ;; 5
 ~~~~
 
@@ -67,7 +67,7 @@ To get the length of a string use length:
 
 To compare two strings use equal:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (equal (String "hello") (String "bob"))) ;; #f
 ($ (equal (String "hello") (String "hello"))) ;; #t
 ~~~~
@@ -78,7 +78,7 @@ The Levenstein Distance is the minimum number of single-character edits (inserti
 
 To get the length of a string use equal:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (levenshtein (String "hello") (String "hello"))) ;; 0
 ($ (levenshtein (String "hello") (String "hedo"))) ;; 2
 ~~~~
@@ -92,10 +92,10 @@ XTlang gives you a number of functions for manipulating and accessing parts of s
 You can remove whitespace using the `trim`, `ltrim` and `rtrim` functions. `ltrim` removes white space at the beginning of a string, `rtrim` removes white space at the end of a string and `trim` removes whitespace at both ends of a string:
 
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (ltrim (String "  hello world  "))) ;; 'hello world  '
 ($ (rtrim (String "  hello world  "))) ;; '  hello world'
-($ (trim  (String "  hello world  "))) ;; 'hello world' 
+($ (trim  (String "  hello world  "))) ;; 'hello world'
 ~~~~
 
 TODO Write `rtrim` and `ltrim`.... :)
@@ -104,7 +104,7 @@ TODO Write `rtrim` and `ltrim`.... :)
 
 You can create substrings from existing strings using substring:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; Returns "rum"
 ($ (substring (String "Scrumptious") 2 5))
 ~~~~
@@ -123,7 +123,7 @@ NOTE: This may change in the future to something safer.
 
 You can combine strings using `cat` and `cat2`:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; returns "hello world"
 ($ (cat2 (String "hello") (String " world")))
 
@@ -140,7 +140,7 @@ You can combine strings using `cat` and `cat2`:
 
 The functions `replace` and `replace_all` can be used to replace parts of a string with a different string. `replace` replaces the first occurrence that it finds, and then returns the string. `replace_all` replaces every occurrence of the string.
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; returns (String "hello your face is my name")
 ($ (replace "hello your name is my name" "name" "face"))
 
@@ -153,7 +153,7 @@ The functions `replace` and `replace_all` can be used to replace parts of a stri
 
 `replace` and `replace_all` can be used with any combination of `String` and String literal that you like:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (replace (String "hello world") "hello" "goodbye"))
 
 ($ (replace "hello world" (String "hello") "goodbye"))

--- a/_docs/reference/scheme-xtlang-interop.md
+++ b/_docs/reference/scheme-xtlang-interop.md
@@ -15,7 +15,7 @@ than that, it's Scheme code.
 A Scheme function (for example named `scheme-foo`) is created by using the
 `define` keyword and a Scheme `lambda` expression:
 
-~~~~ sourceCode
+~~~~ xtlang
 (define scheme-foo
 (lambda (argument1 argument2)
   ;; do some manipulations of the arguments
@@ -27,7 +27,7 @@ A Scheme function (for example named `scheme-foo`) is created by using the
 An xtlang function (for example named `xtlang_bar`) is created by using the
 `bind-func` keyword and an xtlang `lambda` expression:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func xtlang_bar:[type_of_return_value,type_of_argument1,type_of_argument2]*
   (lambda (argument1:type_of_argument1 argument2:type_of_argument2)
     ;; do some manipulations of the arguments
@@ -67,7 +67,7 @@ discussion.
 Sometimes, the Scheme-xtlang interop stuff can be a bit too tricky for its own
 good. Consider this example:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func make_squarer
   (lambda ()
     (lambda (x:double)
@@ -92,7 +92,7 @@ discussed above, all top level xtlang closures (i.e. anything created with
 `bind-func`) have a Scheme wrapper function automatically bound to the same
 name. So in this example:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func squarer:[double,double]*
   (lambda (x)
     (* x x)))
@@ -109,6 +109,6 @@ actually a Scheme function, not a Scheme cptr. The way around this is to make
 sure the final `test_apply` call is an xtlang one using a `$` form the xtlang
 closure as a cptr:
 
-~~~~ sourceCode
+~~~~ xtlang
 ($ (test_apply squarer 2.0))
 ~~~~

--- a/_docs/reference/testing.md
+++ b/_docs/reference/testing.md
@@ -12,7 +12,7 @@ these is the `xtmtest` macro, which takes (up to) three arguments:
 
 Here's an example:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; note the quote (') mark
 (xtmtest
  '(bind-func add_two_integers
@@ -29,7 +29,7 @@ To test an xtlang function multiple times with different arguments, use
 `xtmtest-result` (call this as many times as you like with different arguments
 and return values).
 
-~~~~ sourceCode
+~~~~ xtlang
 (xtmtest-result (add_two_integers 1 5) 6)
 (xtmtest-result (add_two_integers 10 5000) 5010)
 ~~~~
@@ -52,7 +52,9 @@ The easiest way to run the test suite is using CMake/CTest. By default, there's
 a **test** target created in the Extempore configure process, so that on e.g.
 OSX/Linux, you can run all the tests & examples with:
 
+~~~~ sourceCode
     make test
+~~~~
 
 This will take a while, but will give a full report on what works and what's
 broken.
@@ -62,8 +64,10 @@ process will also generate a `CTestTestfile.cmake` file in your build directory,
 and you can execute `ctest` in that directory with additional arguments. One use
 case of this is to only run tests with a certain label:
 
+~~~~ sourceCode
     cd /path/to/CTestTestfile.cmake
     ctest -L libs-core
+~~~~
 
 The tests are partitioned into the following (hopefully self-explanatory)
 labels:
@@ -76,11 +80,15 @@ labels:
 
 To **include** only the labels matching `<regex>`, use:
 
+~~~~ sourceCode
     ctest -L <regex>
+~~~~
 
 To **exclude** only the labels matching `<regex>`, use:
 
+~~~~ sourceCode
     ctest -LE <regex>
+~~~~
 
 ## Get involved {#get-involved}
 

--- a/_docs/reference/type-inference.md
+++ b/_docs/reference/type-inference.md
@@ -15,7 +15,7 @@ of the variables. Look at the code for `xt_add` above---in the argument list
 `(a:i64 b:i64)` both arguments are identified as `i64`. What happens, though, if
 we take out just one of these type annotations?
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func xt_add2
   (lambda (a:i64 b)
     (+ a b)))
@@ -37,7 +37,7 @@ only acceptable type signature for the closure pointer is `[i64,i64,i64]*`.
 
 How about if we try removing the `a` type annotation as well?
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func xt_add3
   (lambda (a b)
     (+ a b)))
@@ -57,7 +57,7 @@ rather than guess, it throws a compile error.
 It's also worth mentioning that we could have specified the closure's type
 directly with the definition of the `xt_add3` symbol
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func xt_add4:[i64,i64,i64]*
   (lambda (a b)
     (+ a b)))
@@ -84,7 +84,7 @@ Scheme.
 
 Here's an example to make things a bit clearer:
 
-~~~~ sourceCode
+~~~~ xtlang
 ;; tuple-maker returns a pointer to a tuple and tuple-taker takes
 ;; a pointer to a tuple as an argument.
 

--- a/_docs/reference/types.md
+++ b/_docs/reference/types.md
@@ -105,7 +105,7 @@ between `salloc`, `halloc` and `zalloc`) can be found in <span
 role="doc">memory</span>. For now, though, we'll just use `zalloc`, which
 allocates memory from the current zone, which for these examples will work fine.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func ptr_test
   (lambda ()
     (let ((a:double* (zalloc)))
@@ -144,7 +144,7 @@ argument, but it also takes an additional third argument---the value to set into
 that memory location. This must be of the appropriate type: so if the pointer is
 to a double, then the value passed to `pset!` must also be a double.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func ptr_test2
   (lambda ()
     (let ((a:double* (zalloc))) ; allocate some memory for a double, bind
@@ -165,7 +165,7 @@ This is important (and useful) because the call to `zalloc` can (optionally)
 take an integer argument. So, if we know we're going to store 4 doubles, we can
 do this:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func ptr_test3
   (lambda ()
     (let ((a:double* (zalloc 4)))
@@ -185,7 +185,7 @@ multiple values into a byte array. Using `pfill!` is exactly the same as calling
 Finally, one more useful way to fill values into a chunk of memory is using a
 loop.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func ptr_test4
   (lambda ()
     (let ((a:double* (zalloc 10))
@@ -219,7 +219,7 @@ String literals in xtlang are bound globally (allocated on the heap). So you can
 safely set and store pointers to them without worrying about then disappearing
 on you.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func string_literals
   (lambda ()
     (let ((str "Vive le tour!"))
@@ -401,7 +401,7 @@ Sometimes, though, we want to give a closure a name, and that's where
 name to a closure. Here's an example of creating a simple (named) xtlang closure
 using `bind-func`
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func xt_add
   (lambda (a:i64 b:i64)
     (+ a b)))
@@ -428,7 +428,7 @@ do the necessary for you.
 As another example, if you want to return a closure from the function it's
 exactly like you would do it in Scheme:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func make_xt_adder
   (lambda (a:i64)
     (lambda (b:i64)
@@ -469,7 +469,7 @@ There are two ways to define a custom type: `bind-type` and `bind-alias`.
 
 Examples:
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-alias my_type_1 <i64,double>)
 (bind-type my_type_2 <float,[i64,i32]*,|3,double|*>)
 ~~~~
@@ -482,14 +482,14 @@ tricky debugging.
 As an example, let's make a 2D 'point' type, and a function for calculating the
 euclidean distance between two points.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-type point <double,double>)
 
 (bind-func euclid_distance
   (lambda (a:point* b:point*)
     (sqrt (+ (pow (- (tref a 0)
-                   (tref b 0))
-                2.0)
+                     (tref b 0))
+                  2.0)
              (pow (- (tref a 1)
                      (tref b 1))
                   2.0)))))
@@ -498,7 +498,7 @@ euclidean distance between two points.
 To test this out, we can check the diagonal length of the unit square, which
 should be `sqrt(2) = 1.41`
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func test_unit_square_diagonal
   (lambda ()
     (let ((bot_left:point* (alloc))
@@ -518,7 +518,7 @@ Now, what happens if we change this testing example to make `top_right` and
 `bot_left` just plain tuples of type `<double,double>` instead of being our new
 `point` type.
 
-~~~~ sourceCode
+~~~~ xtlang
 (bind-func test_unit_square_diagonal_2
   (lambda ()
     (let ((bot_left:<double,double>* (alloc))

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,4 +15,11 @@
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
+    <link rel="stylesheet" href="/js/highlight/styles/xtlang.css">
+    <script src="/js/highlight/highlight.js"></script>
+    <script src="/js/highlight/languages/xtlang.js"></script>
+    <script>
+        hljs.registerLanguage('xtlang', window.hljsDefineXtlang);
+        hljs.initHighlightingOnLoad();
+    </script>
 </head>

--- a/_sass/_syntax-highlighting.scss
+++ b/_sass/_syntax-highlighting.scss
@@ -2,7 +2,7 @@
  * Syntax highlighting styles
  */
 .highlight {
-    background: #fff;
+    background: #f5f5f5;
 
 
     .hll { background-color: #f8f8f8; border: 1px solid #ccc; padding: 6px 10px; border-radius: 3px; }

--- a/js/highlight/highlight.js
+++ b/js/highlight/highlight.js
@@ -1,0 +1,834 @@
+/*
+Syntax highlighting with language autodetection.
+https://highlightjs.org/
+*/
+
+(function(factory) {
+
+  // Find the global object for export to both the browser and web workers.
+  var globalObject = typeof window === 'object' && window ||
+                     typeof self === 'object' && self;
+
+  // Setup highlight.js for different environments. First is Node.js or
+  // CommonJS.
+  if(typeof exports !== 'undefined') {
+    factory(exports);
+  } else if(globalObject) {
+    // Export hljs globally even when using AMD for cases when this script
+    // is loaded with others that may still expect a global hljs.
+    globalObject.hljs = factory({});
+
+    // Finally register the global hljs with AMD.
+    if(typeof define === 'function' && define.amd) {
+      define([], function() {
+        return globalObject.hljs;
+      });
+    }
+  }
+
+}(function(hljs) {
+  // Convenience variables for build-in objects
+  var ArrayProto = [],
+      objectKeys = Object.keys;
+
+  // Global internal variables used within the highlight.js library.
+  var languages = {},
+      aliases   = {};
+
+  // Regular expressions used throughout the highlight.js library.
+  var noHighlightRe    = /^(no-?highlight|plain|text)$/i,
+      languagePrefixRe = /\blang(?:uage)?-([\w-]+)\b/i,
+      fixMarkupRe      = /((^(<[^>]+>|\t|)+|(?:\n)))/gm;
+
+  var spanEndTag = '</span>';
+
+  // Global options used when within external APIs. This is modified when
+  // calling the `hljs.configure` function.
+  var options = {
+    classPrefix: 'hljs-',
+    tabReplace: null,
+    useBR: false,
+    languages: undefined
+  };
+
+
+  /* Utility functions */
+
+  function escape(value) {
+    return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function tag(node) {
+    return node.nodeName.toLowerCase();
+  }
+
+  function testRe(re, lexeme) {
+    var match = re && re.exec(lexeme);
+    return match && match.index === 0;
+  }
+
+  function isNotHighlighted(language) {
+    return noHighlightRe.test(language);
+  }
+
+  function blockLanguage(block) {
+    var i, match, length, _class;
+    var classes = block.className + ' ';
+
+    classes += block.parentNode ? block.parentNode.className : '';
+
+    // language-* takes precedence over non-prefixed class names.
+    match = languagePrefixRe.exec(classes);
+    if (match) {
+      return getLanguage(match[1]) ? match[1] : 'no-highlight';
+    }
+
+    classes = classes.split(/\s+/);
+
+    for (i = 0, length = classes.length; i < length; i++) {
+      _class = classes[i];
+
+      if (isNotHighlighted(_class) || getLanguage(_class)) {
+        return _class;
+      }
+    }
+  }
+
+  function inherit(parent) {  // inherit(parent, override_obj, override_obj, ...)
+    var key;
+    var result = {};
+    var objects = Array.prototype.slice.call(arguments, 1);
+
+    for (key in parent)
+      result[key] = parent[key];
+    objects.forEach(function(obj) {
+      for (key in obj)
+        result[key] = obj[key];
+    });
+    return result;
+  }
+
+  /* Stream merging */
+
+  function nodeStream(node) {
+    var result = [];
+    (function _nodeStream(node, offset) {
+      for (var child = node.firstChild; child; child = child.nextSibling) {
+        if (child.nodeType === 3)
+          offset += child.nodeValue.length;
+        else if (child.nodeType === 1) {
+          result.push({
+            event: 'start',
+            offset: offset,
+            node: child
+          });
+          offset = _nodeStream(child, offset);
+          // Prevent void elements from having an end tag that would actually
+          // double them in the output. There are more void elements in HTML
+          // but we list only those realistically expected in code display.
+          if (!tag(child).match(/br|hr|img|input/)) {
+            result.push({
+              event: 'stop',
+              offset: offset,
+              node: child
+            });
+          }
+        }
+      }
+      return offset;
+    })(node, 0);
+    return result;
+  }
+
+  function mergeStreams(original, highlighted, value) {
+    var processed = 0;
+    var result = '';
+    var nodeStack = [];
+
+    function selectStream() {
+      if (!original.length || !highlighted.length) {
+        return original.length ? original : highlighted;
+      }
+      if (original[0].offset !== highlighted[0].offset) {
+        return (original[0].offset < highlighted[0].offset) ? original : highlighted;
+      }
+
+      /*
+      To avoid starting the stream just before it should stop the order is
+      ensured that original always starts first and closes last:
+
+      if (event1 == 'start' && event2 == 'start')
+        return original;
+      if (event1 == 'start' && event2 == 'stop')
+        return highlighted;
+      if (event1 == 'stop' && event2 == 'start')
+        return original;
+      if (event1 == 'stop' && event2 == 'stop')
+        return highlighted;
+
+      ... which is collapsed to:
+      */
+      return highlighted[0].event === 'start' ? original : highlighted;
+    }
+
+    function open(node) {
+      function attr_str(a) {return ' ' + a.nodeName + '="' + escape(a.value).replace('"', '&quot;') + '"';}
+      result += '<' + tag(node) + ArrayProto.map.call(node.attributes, attr_str).join('') + '>';
+    }
+
+    function close(node) {
+      result += '</' + tag(node) + '>';
+    }
+
+    function render(event) {
+      (event.event === 'start' ? open : close)(event.node);
+    }
+
+    while (original.length || highlighted.length) {
+      var stream = selectStream();
+      result += escape(value.substring(processed, stream[0].offset));
+      processed = stream[0].offset;
+      if (stream === original) {
+        /*
+        On any opening or closing tag of the original markup we first close
+        the entire highlighted node stack, then render the original tag along
+        with all the following original tags at the same offset and then
+        reopen all the tags on the highlighted stack.
+        */
+        nodeStack.reverse().forEach(close);
+        do {
+          render(stream.splice(0, 1)[0]);
+          stream = selectStream();
+        } while (stream === original && stream.length && stream[0].offset === processed);
+        nodeStack.reverse().forEach(open);
+      } else {
+        if (stream[0].event === 'start') {
+          nodeStack.push(stream[0].node);
+        } else {
+          nodeStack.pop();
+        }
+        render(stream.splice(0, 1)[0]);
+      }
+    }
+    return result + escape(value.substr(processed));
+  }
+
+  /* Initialization */
+
+  function expand_mode(mode) {
+    if (mode.variants && !mode.cached_variants) {
+      mode.cached_variants = mode.variants.map(function(variant) {
+        return inherit(mode, {variants: null}, variant);
+      });
+    }
+    return mode.cached_variants || (mode.endsWithParent && [inherit(mode)]) || [mode];
+  }
+
+  function compileLanguage(language) {
+
+    function reStr(re) {
+        return (re && re.source) || re;
+    }
+
+    function langRe(value, global) {
+      return new RegExp(
+        reStr(value),
+        'm' + (language.case_insensitive ? 'i' : '') + (global ? 'g' : '')
+      );
+    }
+
+    function compileMode(mode, parent) {
+      if (mode.compiled)
+        return;
+      mode.compiled = true;
+
+      mode.keywords = mode.keywords || mode.beginKeywords;
+      if (mode.keywords) {
+        var compiled_keywords = {};
+
+        var flatten = function(className, str) {
+          if (language.case_insensitive) {
+            str = str.toLowerCase();
+          }
+          str.split(' ').forEach(function(kw) {
+            var pair = kw.split('|');
+            compiled_keywords[pair[0]] = [className, pair[1] ? Number(pair[1]) : 1];
+          });
+        };
+
+        if (typeof mode.keywords === 'string') { // string
+          flatten('keyword', mode.keywords);
+        } else {
+          objectKeys(mode.keywords).forEach(function (className) {
+            flatten(className, mode.keywords[className]);
+          });
+        }
+        mode.keywords = compiled_keywords;
+      }
+      mode.lexemesRe = langRe(mode.lexemes || /\w+/, true);
+
+      if (parent) {
+        if (mode.beginKeywords) {
+          mode.begin = '\\b(' + mode.beginKeywords.split(' ').join('|') + ')\\b';
+        }
+        if (!mode.begin)
+          mode.begin = /\B|\b/;
+        mode.beginRe = langRe(mode.begin);
+        if (mode.endSameAsBegin)
+          mode.end = mode.begin;
+        if (!mode.end && !mode.endsWithParent)
+          mode.end = /\B|\b/;
+        if (mode.end)
+          mode.endRe = langRe(mode.end);
+        mode.terminator_end = reStr(mode.end) || '';
+        if (mode.endsWithParent && parent.terminator_end)
+          mode.terminator_end += (mode.end ? '|' : '') + parent.terminator_end;
+      }
+      if (mode.illegal)
+        mode.illegalRe = langRe(mode.illegal);
+      if (mode.relevance == null)
+        mode.relevance = 1;
+      if (!mode.contains) {
+        mode.contains = [];
+      }
+      mode.contains = Array.prototype.concat.apply([], mode.contains.map(function(c) {
+        return expand_mode(c === 'self' ? mode : c);
+      }));
+      mode.contains.forEach(function(c) {compileMode(c, mode);});
+
+      if (mode.starts) {
+        compileMode(mode.starts, parent);
+      }
+
+      var terminators =
+        mode.contains.map(function(c) {
+          return c.beginKeywords ? '\\.?(' + c.begin + ')\\.?' : c.begin;
+        })
+        .concat([mode.terminator_end, mode.illegal])
+        .map(reStr)
+        .filter(Boolean);
+      mode.terminators = terminators.length ? langRe(terminators.join('|'), true) : {exec: function(/*s*/) {return null;}};
+    }
+
+    compileMode(language);
+  }
+
+  /*
+  Core highlighting function. Accepts a language name, or an alias, and a
+  string with the code to highlight. Returns an object with the following
+  properties:
+
+  - relevance (int)
+  - value (an HTML string with highlighting markup)
+
+  */
+  function highlight(name, value, ignore_illegals, continuation) {
+
+    function escapeRe(value) {
+      return new RegExp(value.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'm');
+    }
+
+    function subMode(lexeme, mode) {
+      var i, length;
+
+      for (i = 0, length = mode.contains.length; i < length; i++) {
+        if (testRe(mode.contains[i].beginRe, lexeme)) {
+          if (mode.contains[i].endSameAsBegin) {
+            mode.contains[i].endRe = escapeRe( mode.contains[i].beginRe.exec(lexeme)[0] );
+          }
+          return mode.contains[i];
+        }
+      }
+    }
+
+    function endOfMode(mode, lexeme) {
+      if (testRe(mode.endRe, lexeme)) {
+        while (mode.endsParent && mode.parent) {
+          mode = mode.parent;
+        }
+        return mode;
+      }
+      if (mode.endsWithParent) {
+        return endOfMode(mode.parent, lexeme);
+      }
+    }
+
+    function isIllegal(lexeme, mode) {
+      return !ignore_illegals && testRe(mode.illegalRe, lexeme);
+    }
+
+    function keywordMatch(mode, match) {
+      var match_str = language.case_insensitive ? match[0].toLowerCase() : match[0];
+      return mode.keywords.hasOwnProperty(match_str) && mode.keywords[match_str];
+    }
+
+    function buildSpan(classname, insideSpan, leaveOpen, noPrefix) {
+      var classPrefix = noPrefix ? '' : options.classPrefix,
+          openSpan    = '<span class="' + classPrefix,
+          closeSpan   = leaveOpen ? '' : spanEndTag;
+
+      openSpan += classname + '">';
+
+      return openSpan + insideSpan + closeSpan;
+    }
+
+    function processKeywords() {
+      var keyword_match, last_index, match, result;
+
+      if (!top.keywords)
+        return escape(mode_buffer);
+
+      result = '';
+      last_index = 0;
+      top.lexemesRe.lastIndex = 0;
+      match = top.lexemesRe.exec(mode_buffer);
+
+      while (match) {
+        result += escape(mode_buffer.substring(last_index, match.index));
+        keyword_match = keywordMatch(top, match);
+        if (keyword_match) {
+          relevance += keyword_match[1];
+          result += buildSpan(keyword_match[0], escape(match[0]));
+        } else {
+          result += escape(match[0]);
+        }
+        last_index = top.lexemesRe.lastIndex;
+        match = top.lexemesRe.exec(mode_buffer);
+      }
+      return result + escape(mode_buffer.substr(last_index));
+    }
+
+    function processSubLanguage() {
+      var explicit = typeof top.subLanguage === 'string';
+      if (explicit && !languages[top.subLanguage]) {
+        return escape(mode_buffer);
+      }
+
+      var result = explicit ?
+                   highlight(top.subLanguage, mode_buffer, true, continuations[top.subLanguage]) :
+                   highlightAuto(mode_buffer, top.subLanguage.length ? top.subLanguage : undefined);
+
+      // Counting embedded language score towards the host language may be disabled
+      // with zeroing the containing mode relevance. Usecase in point is Markdown that
+      // allows XML everywhere and makes every XML snippet to have a much larger Markdown
+      // score.
+      if (top.relevance > 0) {
+        relevance += result.relevance;
+      }
+      if (explicit) {
+        continuations[top.subLanguage] = result.top;
+      }
+      return buildSpan(result.language, result.value, false, true);
+    }
+
+    function processBuffer() {
+      result += (top.subLanguage != null ? processSubLanguage() : processKeywords());
+      mode_buffer = '';
+    }
+
+    function startNewMode(mode) {
+      result += mode.className? buildSpan(mode.className, '', true): '';
+      top = Object.create(mode, {parent: {value: top}});
+    }
+
+    function processLexeme(buffer, lexeme) {
+
+      mode_buffer += buffer;
+
+      if (lexeme == null) {
+        processBuffer();
+        return 0;
+      }
+
+      var new_mode = subMode(lexeme, top);
+      if (new_mode) {
+        if (new_mode.skip) {
+          mode_buffer += lexeme;
+        } else {
+          if (new_mode.excludeBegin) {
+            mode_buffer += lexeme;
+          }
+          processBuffer();
+          if (!new_mode.returnBegin && !new_mode.excludeBegin) {
+            mode_buffer = lexeme;
+          }
+        }
+        startNewMode(new_mode, lexeme);
+        return new_mode.returnBegin ? 0 : lexeme.length;
+      }
+
+      var end_mode = endOfMode(top, lexeme);
+      if (end_mode) {
+        var origin = top;
+        if (origin.skip) {
+          mode_buffer += lexeme;
+        } else {
+          if (!(origin.returnEnd || origin.excludeEnd)) {
+            mode_buffer += lexeme;
+          }
+          processBuffer();
+          if (origin.excludeEnd) {
+            mode_buffer = lexeme;
+          }
+        }
+        do {
+          if (top.className) {
+            result += spanEndTag;
+          }
+          if (!top.skip && !top.subLanguage) {
+            relevance += top.relevance;
+          }
+          top = top.parent;
+        } while (top !== end_mode.parent);
+        if (end_mode.starts) {
+          if (end_mode.endSameAsBegin) {
+            end_mode.starts.endRe = end_mode.endRe;
+          }
+          startNewMode(end_mode.starts, '');
+        }
+        return origin.returnEnd ? 0 : lexeme.length;
+      }
+
+      if (isIllegal(lexeme, top))
+        throw new Error('Illegal lexeme "' + lexeme + '" for mode "' + (top.className || '<unnamed>') + '"');
+
+      /*
+      Parser should not reach this point as all types of lexemes should be caught
+      earlier, but if it does due to some bug make sure it advances at least one
+      character forward to prevent infinite looping.
+      */
+      mode_buffer += lexeme;
+      return lexeme.length || 1;
+    }
+
+    var language = getLanguage(name);
+    if (!language) {
+      throw new Error('Unknown language: "' + name + '"');
+    }
+
+    compileLanguage(language);
+    var top = continuation || language;
+    var continuations = {}; // keep continuations for sub-languages
+    var result = '', current;
+    for(current = top; current !== language; current = current.parent) {
+      if (current.className) {
+        result = buildSpan(current.className, '', true) + result;
+      }
+    }
+    var mode_buffer = '';
+    var relevance = 0;
+    try {
+      var match, count, index = 0;
+      while (true) {
+        top.terminators.lastIndex = index;
+        match = top.terminators.exec(value);
+        if (!match)
+          break;
+        count = processLexeme(value.substring(index, match.index), match[0]);
+        index = match.index + count;
+      }
+      processLexeme(value.substr(index));
+      for(current = top; current.parent; current = current.parent) { // close dangling modes
+        if (current.className) {
+          result += spanEndTag;
+        }
+      }
+      return {
+        relevance: relevance,
+        value: result,
+        language: name,
+        top: top
+      };
+    } catch (e) {
+      if (e.message && e.message.indexOf('Illegal') !== -1) {
+        return {
+          relevance: 0,
+          value: escape(value)
+        };
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /*
+  Highlighting with language detection. Accepts a string with the code to
+  highlight. Returns an object with the following properties:
+
+  - language (detected language)
+  - relevance (int)
+  - value (an HTML string with highlighting markup)
+  - second_best (object with the same structure for second-best heuristically
+    detected language, may be absent)
+
+  */
+  function highlightAuto(text, languageSubset) {
+    languageSubset = languageSubset || options.languages || objectKeys(languages);
+    var result = {
+      relevance: 0,
+      value: escape(text)
+    };
+    var second_best = result;
+    languageSubset.filter(getLanguage).filter(autoDetection).forEach(function(name) {
+      var current = highlight(name, text, false);
+      current.language = name;
+      if (current.relevance > second_best.relevance) {
+        second_best = current;
+      }
+      if (current.relevance > result.relevance) {
+        second_best = result;
+        result = current;
+      }
+    });
+    if (second_best.language) {
+      result.second_best = second_best;
+    }
+    return result;
+  }
+
+  /*
+  Post-processing of the highlighted markup:
+
+  - replace TABs with something more useful
+  - replace real line-breaks with '<br>' for non-pre containers
+
+  */
+  function fixMarkup(value) {
+    return !(options.tabReplace || options.useBR)
+      ? value
+      : value.replace(fixMarkupRe, function(match, p1) {
+          if (options.useBR && match === '\n') {
+            return '<br>';
+          } else if (options.tabReplace) {
+            return p1.replace(/\t/g, options.tabReplace);
+          }
+          return '';
+      });
+  }
+
+  function buildClassName(prevClassName, currentLang, resultLang) {
+    var language = currentLang ? aliases[currentLang] : resultLang,
+        result   = [prevClassName.trim()];
+
+    if (!prevClassName.match(/\bhljs\b/)) {
+      result.push('hljs');
+    }
+
+    if (prevClassName.indexOf(language) === -1) {
+      result.push(language);
+    }
+
+    return result.join(' ').trim();
+  }
+
+  /*
+  Applies highlighting to a DOM node containing code. Accepts a DOM node and
+  two optional parameters for fixMarkup.
+  */
+  function highlightBlock(block) {
+    var node, originalStream, result, resultNode, text;
+    var language = blockLanguage(block);
+
+    if (isNotHighlighted(language))
+        return;
+
+    if (options.useBR) {
+      node = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+      node.innerHTML = block.innerHTML.replace(/\n/g, '').replace(/<br[ \/]*>/g, '\n');
+    } else {
+      node = block;
+    }
+    text = node.textContent;
+    result = language ? highlight(language, text, true) : highlightAuto(text);
+
+    originalStream = nodeStream(node);
+    if (originalStream.length) {
+      resultNode = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+      resultNode.innerHTML = result.value;
+      result.value = mergeStreams(originalStream, nodeStream(resultNode), text);
+    }
+    result.value = fixMarkup(result.value);
+
+    block.innerHTML = result.value;
+    block.className = buildClassName(block.className, language, result.language);
+    block.result = {
+      language: result.language,
+      re: result.relevance
+    };
+    if (result.second_best) {
+      block.second_best = {
+        language: result.second_best.language,
+        re: result.second_best.relevance
+      };
+    }
+  }
+
+  /*
+  Updates highlight.js global options with values passed in the form of an object.
+  */
+  function configure(user_options) {
+    options = inherit(options, user_options);
+  }
+
+  /*
+  Applies highlighting to all <pre><code>..</code></pre> blocks on a page.
+  */
+  function initHighlighting() {
+    if (initHighlighting.called)
+      return;
+    initHighlighting.called = true;
+
+    var blocks = document.querySelectorAll('pre code');
+    ArrayProto.forEach.call(blocks, highlightBlock);
+  }
+
+  /*
+  Attaches highlighting to the page load event.
+  */
+  function initHighlightingOnLoad() {
+    addEventListener('DOMContentLoaded', initHighlighting, false);
+    addEventListener('load', initHighlighting, false);
+  }
+
+  function registerLanguage(name, language) {
+    var lang = languages[name] = language(hljs);
+    if (lang.aliases) {
+      lang.aliases.forEach(function(alias) {aliases[alias] = name;});
+    }
+  }
+
+  function listLanguages() {
+    return objectKeys(languages);
+  }
+
+  function getLanguage(name) {
+    name = (name || '').toLowerCase();
+    return languages[name] || languages[aliases[name]];
+  }
+
+  function autoDetection(name) {
+    var lang = getLanguage(name);
+    return lang && !lang.disableAutodetect;
+  }
+
+  /* Interface definition */
+
+  hljs.highlight = highlight;
+  hljs.highlightAuto = highlightAuto;
+  hljs.fixMarkup = fixMarkup;
+  hljs.highlightBlock = highlightBlock;
+  hljs.configure = configure;
+  hljs.initHighlighting = initHighlighting;
+  hljs.initHighlightingOnLoad = initHighlightingOnLoad;
+  hljs.registerLanguage = registerLanguage;
+  hljs.listLanguages = listLanguages;
+  hljs.getLanguage = getLanguage;
+  hljs.autoDetection = autoDetection;
+  hljs.inherit = inherit;
+
+  // Common regexps
+  hljs.IDENT_RE = '[a-zA-Z]\\w*';
+  hljs.UNDERSCORE_IDENT_RE = '[a-zA-Z_]\\w*';
+  hljs.NUMBER_RE = '\\b\\d+(\\.\\d+)?';
+  hljs.C_NUMBER_RE = '(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)'; // 0x..., 0..., decimal, float
+  hljs.BINARY_NUMBER_RE = '\\b(0b[01]+)'; // 0b...
+  hljs.RE_STARTERS_RE = '!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~';
+
+  // Common modes
+  hljs.BACKSLASH_ESCAPE = {
+    begin: '\\\\[\\s\\S]', relevance: 0
+  };
+  hljs.APOS_STRING_MODE = {
+    className: 'string',
+    begin: '\'', end: '\'',
+    illegal: '\\n',
+    contains: [hljs.BACKSLASH_ESCAPE]
+  };
+  hljs.QUOTE_STRING_MODE = {
+    className: 'string',
+    begin: '"', end: '"',
+    illegal: '\\n',
+    contains: [hljs.BACKSLASH_ESCAPE]
+  };
+  hljs.PHRASAL_WORDS_MODE = {
+    begin: /\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
+  };
+  hljs.COMMENT = function (begin, end, inherits) {
+    var mode = hljs.inherit(
+      {
+        className: 'comment',
+        begin: begin, end: end,
+        contains: []
+      },
+      inherits || {}
+    );
+    mode.contains.push(hljs.PHRASAL_WORDS_MODE);
+    mode.contains.push({
+      className: 'doctag',
+      begin: '(?:TODO|FIXME|NOTE|BUG|XXX):',
+      relevance: 0
+    });
+    return mode;
+  };
+  hljs.C_LINE_COMMENT_MODE = hljs.COMMENT('//', '$');
+  hljs.C_BLOCK_COMMENT_MODE = hljs.COMMENT('/\\*', '\\*/');
+  hljs.HASH_COMMENT_MODE = hljs.COMMENT('#', '$');
+  hljs.NUMBER_MODE = {
+    className: 'number',
+    begin: hljs.NUMBER_RE,
+    relevance: 0
+  };
+  hljs.C_NUMBER_MODE = {
+    className: 'number',
+    begin: hljs.C_NUMBER_RE,
+    relevance: 0
+  };
+  hljs.BINARY_NUMBER_MODE = {
+    className: 'number',
+    begin: hljs.BINARY_NUMBER_RE,
+    relevance: 0
+  };
+  hljs.CSS_NUMBER_MODE = {
+    className: 'number',
+    begin: hljs.NUMBER_RE + '(' +
+      '%|em|ex|ch|rem'  +
+      '|vw|vh|vmin|vmax' +
+      '|cm|mm|in|pt|pc|px' +
+      '|deg|grad|rad|turn' +
+      '|s|ms' +
+      '|Hz|kHz' +
+      '|dpi|dpcm|dppx' +
+      ')?',
+    relevance: 0
+  };
+  hljs.REGEXP_MODE = {
+    className: 'regexp',
+    begin: /\//, end: /\/[gimuy]*/,
+    illegal: /\n/,
+    contains: [
+      hljs.BACKSLASH_ESCAPE,
+      {
+        begin: /\[/, end: /\]/,
+        relevance: 0,
+        contains: [hljs.BACKSLASH_ESCAPE]
+      }
+    ]
+  };
+  hljs.TITLE_MODE = {
+    className: 'title',
+    begin: hljs.IDENT_RE,
+    relevance: 0
+  };
+  hljs.UNDERSCORE_TITLE_MODE = {
+    className: 'title',
+    begin: hljs.UNDERSCORE_IDENT_RE,
+    relevance: 0
+  };
+  hljs.METHOD_GUARD = {
+    // excludes method names from keyword processing
+    begin: '\\.\\s*' + hljs.UNDERSCORE_IDENT_RE,
+    relevance: 0
+  };
+
+  return hljs;
+}));

--- a/js/highlight/languages/xtlang.js
+++ b/js/highlight/languages/xtlang.js
@@ -1,0 +1,505 @@
+/*
+Language: xtlang
+Description: This is a mixture of Scheme and xtlang for the `Extempore programming environment <https://extemporelang.github.io/>`.
+Author: YUYA CHIBA <cy.blue.9@gmail.com>
+Category: lisp
+*/
+
+var module = module ? module : {}; // shim for browser use
+
+function hljsDefineXtlang(hljs) {
+  var SCHEME_SIMPLE_NUMBER_RE  = '(\\-|\\+|\\.)?\\d+([./]\\d*)?';
+  var SCHEME_COMPLEX_NUMBER_RE = SCHEME_SIMPLE_NUMBER_RE + '[\\+\\-]' +
+                                 SCHEME_SIMPLE_NUMBER_RE + 'i';
+
+  // valid names for Scheme identifiers(names cannot consist fully
+  // of numbers, but this should be good enough for now)
+  var VALID_SCHEME_NAME_RE = '[\\w\\!\\$%&\\*\\+,\\/:<=>\\?@\\^~\\|\\-]+';
+
+  // valid characters in xtlang names & types
+  var VALID_XTLANG_NAME_RE  = '[\\w\\.\\!\\-]+';
+  var VALID_XTLANG_TYPE_RE  = '[\\w\\[\\]\\{\\}<>,\\*/\\|\\!\\-]+';
+  var VALID_XTLANG_TYPE_RE_ = ':(i1|i8|i32|i64|double|float|SAMPLE|NoteData|DSP|' +
+                               'type_of_argument1|type_of_argument2)'             +
+                               '[\\w\\[\\]\\{\\}<>,\\*/\\|\\!\\-]*';
+
+  /*
+   *  Keywords based on
+   *  https://bitbucket.org/birkenfeld/pygments-main/src/7941677dc77d4f2bf0bbd6140ade85a9454b8b80/
+   *  pygments/lexers/lisp.py?at=default&fileviewer=file-view-default#lisp.py-2420
+   */
+  var COMMON_KEYWORDS_RE = '(lambda|define|if|else|cond|and|or|' +
+                            'let|begin|set\\!|map|for\\-each)';
+  var SCHEME_KEYWORDS_RE = '(do|delay|quasiquote|unquote\\-splicing|' +
+                            'eval|case|let\\*|letrec|quote)';
+  var SCHEME_KEYWORDS_OVERLAP_RE = 'unquote';
+  var XTLANG_BIND_KEYWORDS_RE = '(bind\\-func|bind\\-val|bind\\-type|bind\\-alias|' +
+                                 'bind\\-poly|bind\\-dylib|bind\\-lib\\-func|bind\\-lib\\-val)';
+  var XTLANG_BIND_KEYWORDS_OVARLAP_RE = 'bind\\-lib';
+  var XTLANG_KEYWORDS_RE = '(letz|memzone|cast|convert|dotimes|doloop)';
+  var COMMON_FUNCTIONS_RE = '(\\*|\\+|-|/|<|<=|=|>|>=|%|abs|acos|'         +
+                             'angle|append|apply|asin|assoc|assq|assv|'    +
+                             'atan|boolean\\?|caaaar|caaadr|caaar|caadar|' +
+                             'caaddr|caadr|caar|cadaar|cadadr|cadar|'      +
+                             'caddar|cadddr|caddr|cadr|car|cdaaar|'        +
+                             'cdaadr|cdaar|cdadar|cdaddr|cdadr|cdar|'      +
+                             'cddaar|cddadr|cddar|cdddar|cddddr|cdddr|'    +
+                             'cddr|cdr|ceiling|cons|cos|floor|length|'     +
+                             'list|log|max|member|min|modulo|not|'         +
+                             'reverse|round|sin|sqrt|substring|tan|'       +
+                             'println|random|null\\?|callback|now)';
+  var COMMON_FUNCTIONS_OVERLAP_RE = 'print';
+  var SCHEME_FUNCTIONS_RE = '(call\\-with\\-current\\-continuation|'                        +
+                             'call\\-with\\-input\\-file|call\\-with\\-output\\-file|'      +
+                             'call\\-with\\-values|call/cc|char\\->integer|'                +
+                             'char\\-alphabetic\\?|char\\-ci<=\\?|char\\-ci<\\?|'           +
+                             'char\\-ci=\\?|char\\-ci>=\\?|char\\-ci>\\?|char\\-downcase|'  +
+                             'char\\-lower\\-case\\?|char\\-numeric\\?|char\\-ready\\?|'    +
+                             'char\\-upcase|char\\-upper\\-case\\?|char\\-whitespace\\?|'   +
+                             'char<=\\?|char<\\?|char=\\?|char>=\\?|char>\\?|char\\?|'      +
+                             'close\\-input\\-port|close\\-output\\-port|complex\\?|'       +
+                             'current\\-input\\-port|current\\-output\\-port|denominator|'  +
+                             'display|dynamic\\-wind|eof\\-object\\?|eq\\?|equal\\?|'       +
+                             'eqv\\?|even\\?|exact\\->inexact|exact\\?|expt|'               +
+                             'force|gcd|imag\\-part|inexact\\->exact|inexact\\?|'           +
+                             'input\\-port\\?|integer\\->char|integer\\?|'                  +
+                             'interaction\\-environment|lcm|list\\->string|'                +
+                             'list\\->vector|list\\-ref|list\\-tail|list\\?|load|'          +
+                             'magnitude|make\\-polar|make\\-rectangular|make\\-string|'     +
+                             'make\\-vector|memq|memv|negative\\?|newline|'                 +
+                             'null\\-environment|number\\->string|number\\?|'               +
+                             'numerator|odd\\?|open\\-input\\-file|open\\-output\\-file|'   +
+                             'output\\-port\\?|pair\\?|peek\\-char|port\\?|positive\\?|'    +
+                             'procedure\\?|quotient|rational\\?|rationalize|'               +
+                             'read\\-char|real\\-part|real\\?|'                             +
+                             'remainder|scheme\\-report\\-environment|set\\-car\\!|'        +
+                             'set\\-cdr\\!|string\\->list|string\\->number|'                +
+                             'string\\->symbol|string\\-append|string\\-ci<=\\?|'           +
+                             'string\\-ci<\\?|string\\-ci=\\?|string\\-ci>=\\?|'            +
+                             'string\\-ci>\\?|string\\-copy|string\\-fill\\!|'              +
+                             'string\\-length|string\\-ref|string\\-set\\!|string<=\\?|'    +
+                             'string<\\?|string=\\?|string>=\\?|string>\\?|string\\?|'      +
+                             'symbol\\->string|symbol\\?|transcript\\-off|transcript\\-on|' +
+                             'truncate|values|vector\\->list|vector\\-fill\\!|'             +
+                             'vector\\-length|vector\\?|'                                   +
+                             'with\\-input\\-from\\-file|with\\-output\\-to\\-file|write|'  +
+                             'write\\-char|zero\\?)';
+  var SCHEME_FUNCTIONS_OVERLAP_RE = '(exp|read|string|vector)';
+  var XTLANG_FUNCTIONS_RE = '(toString|afill\\!|pfill\\!|tfill\\!|tbind|vfill\\!|'          +
+                             'array\\-fill\\!|pointer\\-fill\\!|tuple\\-fill\\!|'           +
+                             'vector\\-fill\\!|free|~|cset\\!|cref|&|bor|'                  +
+                             'ang\\-names|<<|>>|nil|printf|sprintf|null|now|'               +
+                             'pset\\!|pref\\-ptr|vset\\!|vref|aset\\!|aref\\-ptr|'          +
+                             'tset\\!|tref\\-ptr|salloc|halloc|zalloc|alloc|'               +
+                             'schedule|exp|log|sin|cos|tan|asin|acos|atan|'                 +
+                             'sqrt|expt|floor|ceiling|truncate|round|'                      +
+                             'llvm_printf|push_zone|pop_zone|memzone|callback|'             +
+                             'llvm_sprintf|make\\-array|array\\-set\\!|'                    +
+                             'array\\-ref\\-ptr|pointer\\-set\\!|'                          +
+                             'pointer\\-ref\\-ptr|stack\\-alloc|heap\\-alloc|zone\\-alloc|' +
+                             'make\\-tuple|tuple\\-set\\!|tuple\\-ref\\-ptr|'               +
+                             'closure\\-set\\!|closure\\-ref|pdref|impc_null|'              +
+                             'bitcast|void|ifret|ret\\->|clrun\\->|make\\-env\\-zone|'      +
+                             '<>|dtof|ftod|i1tof|i1tod|i1toi8|i1toi32|i1toi64|'             +
+                             'i8tof|i8tod|i8toi1|i8toi32|i8toi64|i32tof|i32tod|i32toi1|'    +
+                             'i32toi8|i32toi64|i64tof|i64tod|i64toi1|'                      +
+                             'i64toi8|i64toi32)';
+  var XTLANG_FUNCTIONS_OVERLAP_RE = '(tuple\\-ref|array\\-ref|aref|tref|pref|pointer\\-ref|' +
+                                     'make\\-env)';
+  var XTLANG_FUNCTIONS_OVERLAP_RE2 = '(tuple|array)';
+
+  var SHEBANG = {
+    className: 'meta',
+    begin: '^#!',
+    end: '$'
+  };
+
+  var LITERAL = {
+    className: 'literal',
+    begin: '(#t|#f)'
+  };
+
+  var XTLANG_TYPE = {
+    className: 'type',
+    lexemes: VALID_XTLANG_TYPE_RE,
+    relevance: 10,
+    variants: [
+      { begin: VALID_XTLANG_TYPE_RE_ },
+      {
+        // Global variable
+        className: 'variable',
+        begin: '\\*\\w',
+        end: '\\*',
+        lexemes: VALID_SCHEME_NAME_RE
+      },
+      { begin: '(<' + VALID_XTLANG_TYPE_RE + '>|\\|' + VALID_XTLANG_TYPE_RE + '\\||/' +
+               VALID_XTLANG_TYPE_RE + '/|' + VALID_XTLANG_TYPE_RE + '\\*)\\**' }
+    ],
+  };
+
+  var NUMBER = {
+    className: 'number',
+    variants: [
+      { begin: SCHEME_SIMPLE_NUMBER_RE, relevance: 0 },
+      { begin: SCHEME_COMPLEX_NUMBER_RE, relevance: 0 },
+      { begin: '#b[0-1]+(/[0-1]+)?' },
+      { begin: '#o[0-7]+(/[0-7]+)?' },
+      { begin: '#x[0-9a-f]+(/[0-9a-f]+)?' }
+    ]
+  };
+
+  var STRING = {
+    className: 'string',
+    variants: [
+      { begin: '"', end:'"'},
+      { begin: '(#\\\\' + VALID_SCHEME_NAME_RE + '|#\\\\.)' }
+    ],
+    contains: [
+      {
+        className: 'doctag', begin: '@\\w+', lexemes: VALID_XTLANG_NAME_RE
+      }
+    ]
+  };
+
+  var COMMENT = [
+    hljs.COMMENT(
+      ';',
+      '$',
+      {
+        relevance: 0
+      }
+    ),
+    hljs.COMMENT('#\\|', '\\|#')
+  ];
+
+  var IDENT = {
+    className: 'variable',
+    begin: VALID_XTLANG_NAME_RE,
+    relevance: 0
+  };
+
+  var QUOTED_IDENT = {
+    className: 'symbol',
+    begin: '\'' + VALID_SCHEME_NAME_RE
+  };
+
+  var SPECIAL_OPERATORS = {
+    className: 'symbol',
+    begin: '(\'|#|`|,@|,|\\.)'
+  };
+
+  var QUOTED_LIST = {
+    variants: [
+      { begin: /'/ },
+      { begin: '`' }
+    ],
+    contains: [
+      {
+        begin: '\\(', end: '\\)',
+        contains: ['self', LITERAL, STRING, NUMBER, IDENT, QUOTED_IDENT, SPECIAL_OPERATORS]
+      }
+    ]
+  };
+
+  var COMMON_KEYWORDS = [
+    {
+      /* Example:
+       *   "lambdahoge"
+       */
+      className: 'variable',
+      begin: COMMON_KEYWORDS_RE + VALID_SCHEME_NAME_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    },
+    {
+      /* Example:
+       *   "lambda"
+       */
+      className: 'keyword',
+      begin: COMMON_KEYWORDS_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    }
+  ];
+
+  var SCHEME_KEYWORDS = [
+    {
+      /* Example:
+       *   "unquote-splicinghoge"
+       */
+      className: 'variable',
+      begin: SCHEME_KEYWORDS_RE+ VALID_SCHEME_NAME_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    },
+    {
+      /* Example:
+       *   "unquote-splicing"
+       */
+      className: 'keyword',
+      begin: SCHEME_KEYWORDS_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    },
+    {
+      /* Example:
+       *   "unquotehoge"
+       */
+      className: 'variable',
+      begin: SCHEME_KEYWORDS_OVERLAP_RE + VALID_SCHEME_NAME_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    },
+    {
+      /* Example:
+       *   "unquote"
+       */
+      className: 'keyword',
+      begin: SCHEME_KEYWORDS_OVERLAP_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    }
+  ]
+
+  var XTLANG_KEYWORDS = [
+    {
+      /* Example:
+       *   "letzhoge"
+       */
+      className: 'variable',
+      begin: XTLANG_KEYWORDS_RE + VALID_XTLANG_NAME_RE,
+      lexemes: VALID_XTLANG_NAME_RE
+    },
+    {
+      /* Example:
+       *   "letz"
+       */
+      className: 'keyword',
+      begin: XTLANG_KEYWORDS_RE,
+      lexemes: VALID_XTLANG_NAME_RE
+    }
+  ];
+
+  var COMMON_FUNCTIONS = [
+    {
+      /* Example:
+       *   "printlnhoge"
+       */
+      className: 'variable',
+      begin: COMMON_FUNCTIONS_RE + VALID_SCHEME_NAME_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    },
+    {
+      /* Example:
+       *   "prinln"
+       */
+      className: 'funciton',
+      begin: COMMON_FUNCTIONS_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    },
+    {
+      /* Example:
+       *   "printhoge"
+       */
+      className: 'variable',
+      begin: COMMON_FUNCTIONS_OVERLAP_RE + VALID_SCHEME_NAME_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    },
+    {
+      /* Example:
+       *   "print"
+       */
+      className: 'funciton',
+      begin: COMMON_FUNCTIONS_OVERLAP_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    }
+  ];
+
+  var SCHEME_FUNCTIONS = [
+    {
+      /* Example:
+       *   "read-charhoge"
+       */
+      className: 'variable',
+      begin: SCHEME_FUNCTIONS_RE + VALID_SCHEME_NAME_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    },
+    {
+      /* Example:
+       *   "read-char"
+       */
+      className: 'funciton',
+      begin: SCHEME_FUNCTIONS_RE,
+      lexemes: VALID_SCHEME_NAME_RE,
+    },
+    {
+      /* Example:
+       *   "readhoge"
+       */
+      className: 'variable',
+      begin: SCHEME_FUNCTIONS_OVERLAP_RE + VALID_SCHEME_NAME_RE,
+      lexemes: VALID_SCHEME_NAME_RE
+    },
+    {
+      /* Example:
+       *   "read"
+       */
+      className: 'funciton',
+      begin: SCHEME_FUNCTIONS_OVERLAP_RE,
+      lexemes: VALID_SCHEME_NAME_RE,
+    }
+  ];
+
+  var XTLANG_FUNCTIONS = [
+    {
+      /* Example:
+       *   "tuple-ref-ptrhoge"
+       */
+      className: 'variable',
+      begin: XTLANG_FUNCTIONS_RE + VALID_XTLANG_NAME_RE,
+      lexemes: VALID_XTLANG_NAME_RE
+    },
+    {
+      /* Example:
+       *   "tuple-ref-ptr"
+       */
+      className: 'funciton',
+      begin: XTLANG_FUNCTIONS_RE,
+      lexemes: VALID_XTLANG_NAME_RE
+    },
+    {
+      /* Example:
+       *  "tuple-refhoge"
+       */
+      className: 'variable',
+      begin: XTLANG_FUNCTIONS_OVERLAP_RE + VALID_XTLANG_NAME_RE,
+      lexemes: VALID_XTLANG_NAME_RE
+    },
+    {
+      /* Example:
+       *   "tuple-ref"
+       */
+      className: 'funciton',
+      begin: XTLANG_FUNCTIONS_OVERLAP_RE,
+      lexemes: VALID_XTLANG_NAME_RE
+    },
+    {
+      /* Example:
+       *   "tuplehoge"
+       */
+      className: 'variable',
+      begin: XTLANG_FUNCTIONS_OVERLAP_RE2 + VALID_XTLANG_NAME_RE,
+      lexemes: VALID_XTLANG_NAME_RE
+    },
+    {
+      /* Example:
+       *   "tuple"
+       */
+      className: 'funciton',
+      begin: XTLANG_FUNCTIONS_OVERLAP_RE2,
+      lexemes: VALID_XTLANG_NAME_RE
+    }
+  ]
+
+  var DEFINE = {
+    className: 'keyword',
+    lexemes: VALID_SCHEME_NAME_RE,
+    end: '$',
+    variants : [
+      {
+        /* Example:
+         *   "bind-lib-funchoge"
+         */
+        className: 'variable',
+        begin: XTLANG_BIND_KEYWORDS_RE + VALID_XTLANG_NAME_RE,
+      },
+      {
+        /* Example:
+         *   "bind-lib-func"
+         */
+        begin: XTLANG_BIND_KEYWORDS_RE,
+        relevance: 10
+      },
+      {
+        /* Example:
+         *   "bind-libhoge"
+         */
+        className: 'variable',
+        begin: XTLANG_BIND_KEYWORDS_OVARLAP_RE + VALID_XTLANG_NAME_RE,
+      },
+      {
+        /* Example:
+         *   "bind-lib"
+         */
+        begin: XTLANG_BIND_KEYWORDS_OVARLAP_RE,
+        relevance: 10
+      },
+      {
+        /* Example:
+         *   "definehoge"
+         */
+        className: 'variable',
+        begin: 'define' + VALID_XTLANG_NAME_RE
+      },
+      {
+        /* Example:
+         *   "define"
+         */
+        begin: 'define'
+      }
+    ],
+    contains: [
+      {
+        /*
+         * for file path(string)
+         * Example:
+         *   (bind-dylib "kiss_fft.dylib")
+         */
+        className: 'string',
+        begin: '"', end: '"',
+        endsParent: true
+      },
+      hljs.inherit(hljs.TITLE_MODE, { begin: VALID_SCHEME_NAME_RE, endsParent: true })
+    ]
+  };
+
+  var XTLANG = {
+    lexemes: VALID_SCHEME_NAME_RE,
+    endsParent: true,
+    variants: [
+    ].concat(XTLANG_KEYWORDS, XTLANG_FUNCTIONS)
+  };
+
+  var SCHEME = {
+    lexemes: VALID_SCHEME_NAME_RE,
+    endsParent: true,
+    variants: [
+    ].concat(SCHEME_KEYWORDS, SCHEME_FUNCTIONS)
+  };
+
+  var COMMON = {
+    endsParent: true
+  };
+
+  var LIST = {
+    variants: [
+      { begin: '\\(', end: '\\)' },
+      { begin: '\\[', end: '\\]' }
+    ],
+    contains: [DEFINE, XTLANG, SCHEME, COMMON]
+  };
+
+  COMMON.contains = [LITERAL, NUMBER, XTLANG_TYPE, STRING, QUOTED_IDENT,
+                     SPECIAL_OPERATORS, QUOTED_LIST
+                    ].concat(COMMON_KEYWORDS, COMMON_FUNCTIONS);
+  COMMON.contains.push(IDENT, LIST);
+  COMMON.contains.concat(COMMENT);
+
+  return {
+    aliases: ['xtm'],
+    illegal: /\S/,
+    contains: [
+      SHEBANG, NUMBER, XTLANG_TYPE, STRING, QUOTED_IDENT, SPECIAL_OPERATORS, QUOTED_LIST, IDENT ,LIST
+    ].concat(COMMENT)
+  };
+};
+
+module.exports = function (hljs) {
+  hljs.registerLanguage('xtlang', hljsDefineXtlang);
+};
+
+module.exports.definer = hljsDefineXtlang;

--- a/js/highlight/styles/xtlang.css
+++ b/js/highlight/styles/xtlang.css
@@ -1,0 +1,117 @@
+/*
+
+xtlang style (c) Yuya Chiba <cy.blue.9@gmail.com>
+
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #f5f5f5;
+}
+
+
+/* Base color: saturation 0; */
+
+
+.hljs,
+.hljs-subst {
+  color: #444;
+}
+
+
+.hljs-comment {
+  color: #888888;
+}
+
+.hljs-keyword,
+.hljs-attribute,
+.hljs-selector-tag,
+.hljs-meta-keyword,
+.hljs-doctag,
+.hljs-name {
+  /* font-weight: bold; */
+  color: #eb32bc;
+}
+
+
+/* User color: hue: 0 */
+.hljs-variable,
+.hljs-template-variable, {
+  color: #000000
+}
+
+.hljs-number {
+  color: #49cee6;
+}
+
+.hljs-type {
+  color: #005bbb;
+}
+
+.hljs-string {
+  color: #4fb129;
+}
+
+.hljs-funciton {
+  color: #b349dd;
+}
+
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-quote,
+.hljs-template-tag,
+.hljs-deletion {
+  color: #64ccde;
+}
+
+.hljs-title,
+.hljs-section {
+  color: #880000;
+  /* font-weight: bold; */
+}
+
+.hljs-regexp,
+.hljs-symbol,
+.hljs-link,
+.hljs-selector-attr,
+.hljs-selector-pseudo {
+  color: #BC6060;
+}
+
+
+/* Language color: hue: 90; */
+
+.hljs-literal {
+  color: #78A960;
+}
+
+.hljs-built_in,
+.hljs-bullet,
+.hljs-code,
+.hljs-addition {
+  color: #397300;
+}
+
+
+/* Meta color: hue: 200 */
+
+.hljs-meta {
+  color: #1f7199;
+}
+
+.hljs-meta-string {
+  color: #4d99bf;
+}
+
+
+/* Misc effects */
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}


### PR DESCRIPTION
Hi, @benswift!

Completed to add syntax highlight for xtlang of this document!!! 😊
(https://github.com/extemporelang/highlight.js/issues/1)

After finished to creat [highlightjs-xtlang repo](https://github.com/highlightjs/highlightjs-xtlang), I tried to migrate it to here.
But it did not work. Because, there are problem in hilight.js.(https://github.com/highlightjs/highlight.js/pull/1888)
Apparently [highlightjs-xtlang repo](https://github.com/highlightjs/highlightjs-xtlang) does not seem to work ...😥

So, I copied [highlight.js source](https://github.com/highlightjs/highlight.js/blob/master/src/highlight.js) and [highlightjs-xtlang source](https://github.com/highlightjs/highlightjs-xtlang/blob/master/xtlang.js) to /js/hightlight/.

Images:
<img width="750" alt="2018-11-27 22 42 24" src="https://user-images.githubusercontent.com/16382693/49089166-4a4b3f00-f29e-11e8-8b36-32db9696de7a.png">

<img width="501" alt="2018-11-28 0 03 03" src="https://user-images.githubusercontent.com/16382693/49090536-4a990980-f2a1-11e8-9ccd-e849090c3883.png">

 I confirmed to working in all page of document by sight, all were OK!😄

If you do not like highlight color, please change freedom! (/js/highlight/styles/xtlang.css)

Please review!
(Sorry that the commit size got bigger.)
