### PR TITLE
Hopefully fix the anchor

### DIFF
--- a/_docs/overview/quickstart.md
+++ b/_docs/overview/quickstart.md
@@ -78,7 +78,7 @@ physics).
 OpenGL state machine requires a bit of boilerplate. See
 `examples/external/shader-tutorials/triangle.xtm` to get started.
 
-## Beyond "Hello..." {#beyond-hello...}
+## Beyond "Hello..." {#beyond-hello}
 
 These simple snippets gloss over some subtleties of what's going on. But
 hey, if you've started quickly(ish), then this page has done its job. To


### PR DESCRIPTION
This is untested. Dropping the braces would probably also work for the main site, provided Jeckyl creates an anchor when you don't provide it explicitly, but I kept it for consistency.

<img width="737" alt="Screen Shot 2019-05-14 at 14 28 57" src="https://user-images.githubusercontent.com/54515/57698115-1a79d300-7655-11e9-9c48-b18e5dc30550.png">
